### PR TITLE
feat: add message type filter to view command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ Auto-generated from all feature plans. Last updated: 2025-12-31
 ## Active Technologies
 - TypeScript 5.x with strict mode (matching lib layer) + Commander.js (CLI framework), chalk (terminal colors - optional), existing `src/lib/` exports (002-cli-ui-layer)
 - N/A (reads from Claude Code's `~/.claude/projects/` via lib layer) (002-cli-ui-layer)
+- TypeScript 5.x with strict mode enabled + Commander.js (CLI framework), Node.js built-ins (003-message-type-filter)
 
 - TypeScript 5.x with strict mode enabled + Node.js built-ins (fs, path, os, readline); minimal external deps (001-core-lib)
 
@@ -70,6 +71,7 @@ cch -f view 0                        # Full output (no paging)
 TypeScript 5.x with strict mode enabled: Follow standard conventions
 
 ## Recent Changes
+- 003-message-type-filter: Added TypeScript 5.x with strict mode enabled + Commander.js (CLI framework), Node.js built-ins
 - 002-cli-ui-layer: Added TypeScript 5.x with strict mode (matching lib layer) + Commander.js (CLI framework), chalk (terminal colors - optional), existing `src/lib/` exports
 
 - 001-core-lib: Added TypeScript 5.x with strict mode enabled + Node.js built-ins (fs, path, os, readline); minimal external deps

--- a/specs/003-message-type-filter/checklists/requirements.md
+++ b/specs/003-message-type-filter/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Message Type Filter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec includes clarification from previous session (2026-01-11) adding `thinking` and `error` filter types
+- All 5 filter types (user, assistant, tool, thinking, error) are clearly defined
+- Message type classification rules are specified without implementation details
+- All items pass validation - ready for `/speckit.clarify` or `/speckit.plan`

--- a/specs/003-message-type-filter/contracts/cli-interface.md
+++ b/specs/003-message-type-filter/contracts/cli-interface.md
@@ -1,0 +1,210 @@
+# CLI Interface Contract: Message Type Filter
+
+**Feature**: 003-message-type-filter
+**Date**: 2026-01-12
+
+## Overview
+
+This document defines the CLI interface additions for the message type filter feature.
+
+## Command: `view`
+
+### New Option: `--only`
+
+```
+-o, --only <types>    Filter messages by type (user,assistant,tool,thinking,error)
+```
+
+**Syntax**:
+```bash
+cch view <session> --only <type>[,<type>...]
+```
+
+**Parameters**:
+- `<types>`: Comma-separated list of message types to include
+- Valid types: `user`, `assistant`, `tool`, `thinking`, `error`
+
+### Examples
+
+```bash
+# Show only user messages
+cch view 0 --only user
+
+# Show only tool calls
+cch view 0 --only tool
+
+# Show user messages and tool calls
+cch view 0 --only user,tool
+
+# Show everything except assistant explanations
+cch view 0 --only user,tool,thinking,error
+
+# Combined with JSON output
+cch view 0 --only tool --json
+
+# Combined with full output (no paging)
+cch view 0 --only user --full
+```
+
+### Option Interactions
+
+| Option Combination | Behavior |
+|--------------------|----------|
+| `--only` alone | Filter applied, human-readable output |
+| `--only --json` | Filter applied, JSON output with filtered messages |
+| `--only --full` | Filter applied, no paging |
+| `--only --json --full` | Filter + JSON (--full has no effect on JSON) |
+
+### Output Formats
+
+#### Human-Readable (default)
+
+```
+Session: abc123-def456-...
+Project: /path/to/project
+Started: 2026-01-12 10:30:45
+Messages: 5 (filtered from 50)
+Branch: main
+
+────────────────────────────────────────────────────────────────────────────────
+
+[10:30:45] USER
+How do I fix this bug?
+
+────────────────────────────────────────────────────────────────────────────────
+
+[10:31:02] USER
+Can you show me the file?
+
+────────────────────────────────────────────────────────────────────────────────
+```
+
+**Note**: Header shows `Messages: X (filtered from Y)` when filter is active.
+
+#### JSON Output
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "abc123-def456-...",
+    "projectPath": "/path/to/project",
+    "timestamp": "2026-01-12T10:30:45.000Z",
+    "messageCount": 5,
+    "totalMessageCount": 50,
+    "filter": ["user"],
+    "messages": [
+      {
+        "type": "user",
+        "uuid": "...",
+        "timestamp": "2026-01-12T10:30:45.000Z",
+        "content": "How do I fix this bug?"
+      }
+    ]
+  }
+}
+```
+
+**Note**: JSON includes `totalMessageCount` and `filter` fields when filtering is active.
+
+### Error Handling
+
+#### Invalid Filter Type
+
+```bash
+$ cch view 0 --only invalid
+```
+
+**Output** (stderr):
+```
+Error: Invalid filter type 'invalid'
+Valid types: user, assistant, tool, thinking, error
+```
+
+**Exit code**: 1
+
+#### No Matching Messages
+
+```bash
+$ cch view 0 --only thinking
+```
+
+**Output** (stdout):
+```
+Session: abc123-def456-...
+Project: /path/to/project
+Started: 2026-01-12 10:30:45
+
+No messages match filter: thinking
+```
+
+**Exit code**: 0 (success - the operation completed, just no results)
+
+#### JSON with No Matches
+
+```bash
+$ cch view 0 --only thinking --json
+```
+
+**Output**:
+```json
+{
+  "success": true,
+  "data": {
+    "id": "abc123-def456-...",
+    "messageCount": 0,
+    "totalMessageCount": 50,
+    "filter": ["thinking"],
+    "messages": []
+  }
+}
+```
+
+### Help Text
+
+```
+Usage: cch view [options] <session>
+
+View a session's contents
+
+Arguments:
+  session               Session index (0 = most recent) or UUID
+
+Options:
+  -o, --only <types>    Filter messages by type (user,assistant,tool,thinking,error)
+  -j, --json            Output as JSON
+  -f, --full            Disable paging (show all output at once)
+  -h, --help            display help for command
+
+Filter Types:
+  user       - Your messages (questions, prompts)
+  assistant  - AI text responses (excludes tool calls)
+  tool       - Tool invocations (Read, Write, Bash, etc.)
+  thinking   - AI reasoning/thinking blocks
+  error      - Tool results that returned errors
+
+Examples:
+  cch view 0 --only user           Show only your messages
+  cch view 0 --only tool           Show only tool calls
+  cch view 0 --only user,tool      Show your messages and tool calls
+```
+
+## Validation Rules
+
+1. **Case Sensitivity**: Types must be lowercase
+   - `--only User` → Error
+   - `--only USER` → Error
+   - `--only user` → Valid
+
+2. **Whitespace Handling**: Spaces around commas are trimmed
+   - `--only "user, tool"` → Valid (parsed as `['user', 'tool']`)
+   - `--only " user , tool "` → Valid
+
+3. **Duplicates**: Allowed but have no additional effect
+   - `--only user,user,user` → Same as `--only user`
+
+4. **Empty Value**: Shows error
+   - `--only ""` → Error: "Filter type required"
+
+5. **All Types**: Equivalent to no filter
+   - `--only user,assistant,tool,thinking,error` → Shows all messages

--- a/specs/003-message-type-filter/contracts/library-api.md
+++ b/specs/003-message-type-filter/contracts/library-api.md
@@ -1,0 +1,184 @@
+# Library API Contract: Message Type Filter
+
+**Feature**: 003-message-type-filter
+**Date**: 2026-01-12
+
+## Overview
+
+This document defines the public API additions to the `claude-code-history` library for message type filtering.
+
+## New Types
+
+### FilterableMessageType
+
+```typescript
+/**
+ * Message types that can be filtered in session views.
+ *
+ * @remarks
+ * - `user`: User-authored messages (questions, prompts)
+ * - `assistant`: AI text responses (excludes tool calls and thinking)
+ * - `tool`: Tool invocations (Read, Write, Bash, etc.)
+ * - `thinking`: AI reasoning/thinking blocks
+ * - `error`: Tool results with errors
+ */
+export type FilterableMessageType = 'user' | 'assistant' | 'tool' | 'thinking' | 'error';
+```
+
+### MessageFilterOptions
+
+```typescript
+/**
+ * Options for filtering messages in a session.
+ */
+export interface MessageFilterOptions {
+  /**
+   * Message types to include.
+   * Empty array or undefined means include all types.
+   */
+  only?: FilterableMessageType[];
+}
+```
+
+## New Functions
+
+### filterMessages
+
+```typescript
+/**
+ * Filter messages by type.
+ *
+ * @param messages - Array of messages to filter
+ * @param options - Filter options specifying which types to include
+ * @returns Filtered array of messages
+ *
+ * @remarks
+ * - If `options.only` is empty or undefined, returns all messages
+ * - Messages with mixed content (e.g., text + tool_use) are included
+ *   if ANY content block matches the filter
+ * - Order and timestamps are preserved
+ * - Summary and file-history-snapshot messages are always excluded
+ *
+ * @example
+ * ```typescript
+ * import { filterMessages } from 'claude-code-history';
+ *
+ * // Filter to only user messages
+ * const userMessages = filterMessages(session.messages, { only: ['user'] });
+ *
+ * // Filter to tools and errors
+ * const toolsAndErrors = filterMessages(session.messages, { only: ['tool', 'error'] });
+ *
+ * // No filter (returns all displayable messages)
+ * const allMessages = filterMessages(session.messages, {});
+ * ```
+ */
+export function filterMessages(
+  messages: Message[],
+  options?: MessageFilterOptions
+): Message[];
+```
+
+### classifyMessage
+
+```typescript
+/**
+ * Classify a message into filterable types.
+ *
+ * @param message - Message to classify
+ * @returns Array of applicable filter types for this message
+ *
+ * @remarks
+ * A message can have multiple classifications (e.g., an assistant message
+ * with both text and tool_use content will return ['assistant', 'tool']).
+ *
+ * Returns empty array for non-displayable messages (summary, file-history-snapshot).
+ *
+ * @example
+ * ```typescript
+ * import { classifyMessage } from 'claude-code-history';
+ *
+ * const types = classifyMessage(message);
+ * // For user message: ['user']
+ * // For assistant with text + tool: ['assistant', 'tool']
+ * // For user with error result: ['error']
+ * ```
+ */
+export function classifyMessage(message: Message): FilterableMessageType[];
+```
+
+### VALID_FILTER_TYPES
+
+```typescript
+/**
+ * Array of valid filter type strings for validation.
+ */
+export const VALID_FILTER_TYPES: readonly FilterableMessageType[] = [
+  'user',
+  'assistant',
+  'tool',
+  'thinking',
+  'error'
+] as const;
+```
+
+## Extended Types (Optional)
+
+### LibraryConfig Extension
+
+If filter functionality is exposed at the `getSession` level (optional enhancement):
+
+```typescript
+export interface LibraryConfig {
+  // ... existing fields ...
+
+  /**
+   * Filter messages by type when retrieving session.
+   * If not specified, all messages are included.
+   */
+  messageFilter?: MessageFilterOptions;
+}
+```
+
+## Error Handling
+
+No new error types. Invalid filter values should be caught at the CLI validation layer before reaching library functions.
+
+Library functions handle edge cases gracefully:
+- Empty messages array → returns empty array
+- Empty/undefined filter → returns all displayable messages
+- Unknown message types → excluded from results (defensive)
+
+## Backward Compatibility
+
+All additions are purely additive:
+- New types don't conflict with existing types
+- New functions don't modify existing function signatures
+- Existing code continues to work unchanged
+- New `messageFilter` in LibraryConfig is optional
+
+## Usage in CLI
+
+The CLI layer will use these APIs as follows:
+
+```typescript
+// In src/cli/commands/view.ts
+import { getSession, filterMessages, VALID_FILTER_TYPES } from '../../lib/index.js';
+
+// Validate filter types
+function validateFilterTypes(input: string): FilterableMessageType[] {
+  const types = input.split(',').map(t => t.trim().toLowerCase());
+  for (const type of types) {
+    if (!VALID_FILTER_TYPES.includes(type as FilterableMessageType)) {
+      throw new Error(`Invalid filter type '${type}'. Valid types: ${VALID_FILTER_TYPES.join(', ')}`);
+    }
+  }
+  return types as FilterableMessageType[];
+}
+
+// In command execution
+const session = await getSession(sessionRef, libConfig);
+const filteredMessages = options.only
+  ? filterMessages(session.messages, { only: validateFilterTypes(options.only) })
+  : session.messages;
+```

--- a/specs/003-message-type-filter/data-model.md
+++ b/specs/003-message-type-filter/data-model.md
@@ -1,0 +1,166 @@
+# Data Model: Message Type Filter
+
+**Feature**: 003-message-type-filter
+**Date**: 2026-01-12
+
+## Overview
+
+This feature introduces filtering capability to the message display system. The data model extends existing types rather than introducing new entities.
+
+## New Types
+
+### FilterableMessageType
+
+A union type representing the five filterable message categories.
+
+```typescript
+/**
+ * Message types that can be filtered in the view command.
+ */
+export type FilterableMessageType = 'user' | 'assistant' | 'tool' | 'thinking' | 'error';
+```
+
+**Validation Rules**:
+- Must be one of the five defined values
+- Case-sensitive (lowercase only)
+
+### MessageTypeFilter
+
+Configuration for filtering messages.
+
+```typescript
+/**
+ * Filter configuration for message display.
+ */
+export interface MessageTypeFilter {
+  /** Message types to include (empty = all types) */
+  types: FilterableMessageType[];
+}
+```
+
+**Validation Rules**:
+- Empty array means no filtering (show all)
+- Duplicate types are allowed but have no additional effect
+- Invalid types should be rejected at parse time
+
+## Type Relationships
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Existing Types (read-only)                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Message (union)                                                 │
+│  ├── UserMessage          → maps to: 'user', 'error'            │
+│  │   └── content: string | ToolResultContent[]                  │
+│  │       └── ToolResultContent.is_error → 'error'               │
+│  │                                                               │
+│  ├── AssistantMessage     → maps to: 'assistant', 'tool',       │
+│  │   │                               'thinking'                  │
+│  │   └── content: AssistantContent[]                            │
+│  │       ├── TextContent (type: 'text')     → 'assistant'       │
+│  │       ├── ToolUseContent (type: 'tool_use') → 'tool'         │
+│  │       └── ThinkingContent (type: 'thinking') → 'thinking'    │
+│  │                                                               │
+│  ├── SummaryMessage       → excluded from filtering              │
+│  └── FileHistorySnapshot  → excluded from filtering              │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      New Types (this feature)                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  FilterableMessageType = 'user' | 'assistant' | 'tool' |        │
+│                          'thinking' | 'error'                    │
+│                                                                  │
+│  MessageTypeFilter {                                             │
+│    types: FilterableMessageType[]                                │
+│  }                                                               │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Classification Logic
+
+### Message → FilterableMessageType Mapping
+
+| Source Type | Condition | Maps To |
+|-------------|-----------|---------|
+| UserMessage | content is string | `'user'` |
+| UserMessage | content has ToolResultContent with is_error=true | `'error'` |
+| UserMessage | content has ToolResultContent (no errors) | (excluded - tool results shown inline) |
+| AssistantMessage | has TextContent block | `'assistant'` |
+| AssistantMessage | has ToolUseContent block | `'tool'` |
+| AssistantMessage | has ThinkingContent block | `'thinking'` |
+| SummaryMessage | always | (excluded from view) |
+| FileHistorySnapshot | always | (excluded from view) |
+
+### Mixed Content Handling
+
+An AssistantMessage can contain multiple content block types. Per FR-010:
+
+**Rule**: Message is included if ANY content block matches the filter.
+
+Example:
+```typescript
+// AssistantMessage with both text and tool_use
+{
+  type: 'assistant',
+  content: [
+    { type: 'text', text: 'Let me read the file...' },
+    { type: 'tool_use', name: 'Read', input: { file_path: '/foo' } }
+  ]
+}
+
+// With --only tool: INCLUDED (has tool_use block)
+// With --only assistant: INCLUDED (has text block)
+// With --only thinking: EXCLUDED (no thinking block)
+```
+
+## State Transitions
+
+N/A - This feature is stateless. Filtering is applied at display time without modifying source data.
+
+## Validation Requirements
+
+### CLI Input Validation
+
+1. **Parse comma-separated values**: `"user,tool"` → `['user', 'tool']`
+2. **Trim whitespace**: `" user , tool "` → `['user', 'tool']`
+3. **Reject invalid types**: Show error with valid options list
+4. **Case sensitivity**: `"User"` or `"USER"` → error (must be lowercase)
+
+### Filter Application Validation
+
+1. **Empty filter array**: Show all messages (no filtering)
+2. **All types specified**: Equivalent to no filter
+3. **No matching messages**: Display informative message, not empty output
+
+## Data Flow
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   CLI Args   │────▶│  Validator   │────▶│   Filter     │
+│  --only user │     │  (config.ts) │     │  Object      │
+└──────────────┘     └──────────────┘     └──────────────┘
+                                                 │
+                                                 ▼
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Session    │────▶│  filterMsgs  │◀────│   Filter     │
+│   Messages   │     │ (session.ts) │     │   Object     │
+└──────────────┘     └──────────────┘     └──────────────┘
+                            │
+                            ▼
+                     ┌──────────────┐
+                     │  Filtered    │
+                     │  Messages    │
+                     └──────────────┘
+                            │
+                            ▼
+┌──────────────┐     ┌──────────────┐
+│  Formatter   │────▶│   Output     │
+│ (session.ts) │     │  (stdout)    │
+└──────────────┘     └──────────────┘
+```

--- a/specs/003-message-type-filter/plan.md
+++ b/specs/003-message-type-filter/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Message Type Filter
+
+**Branch**: `003-message-type-filter` | **Date**: 2026-01-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-message-type-filter/spec.md`
+
+## Summary
+
+Add a `--only <type>` option to the `cch view` command that filters displayed messages by type (user, assistant, tool, thinking, error). The filter leverages the existing structured type system in the library layer and integrates with the CLI's view command and session formatter.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x with strict mode enabled
+**Primary Dependencies**: Commander.js (CLI framework), Node.js built-ins
+**Storage**: N/A (reads from Claude Code's `~/.claude/projects/` via lib layer)
+**Testing**: Vitest for unit and integration testing
+**Target Platform**: Cross-platform (macOS, Windows, Linux)
+**Project Type**: Single project (library + CLI)
+**Performance Goals**: Filter 100+ message session in under 1 second
+**Constraints**: Non-destructive read operations only
+**Scale/Scope**: Single command enhancement, ~5 filter types
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Design | ✅ Pass | `--only <type>` follows existing option patterns; supports JSON output |
+| II. Non-Destructive Operations | ✅ Pass | Read-only filtering at display time |
+| III. Cross-Platform Compatibility | ✅ Pass | No platform-specific code required |
+| IV. Library-First Architecture | ✅ Pass | Filter logic in lib, CLI consumes it |
+| V. Data Fidelity | ✅ Pass | Filtering doesn't modify source data |
+
+**Technical Standards Compliance**:
+- ESLint/Prettier enforced ✅
+- JSDoc for public APIs ✅
+- Vitest testing ✅
+- Minimal dependencies (no new deps needed) ✅
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-message-type-filter/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cli/
+│   ├── commands/
+│   │   └── view.ts      # Add --only option here
+│   ├── formatters/
+│   │   └── session.ts   # Add filter application here
+│   └── utils/
+│       └── config.ts    # Add filter type validation
+└── lib/
+    ├── types.ts         # Add MessageTypeFilter type
+    ├── session.ts       # Add filterMessages function
+    └── index.ts         # Export new types/functions
+
+tests/
+├── integration/
+│   └── cli/
+│       └── view.test.ts # CLI integration tests for --only
+└── unit/
+    ├── cli/
+    │   └── formatters/
+    │       └── session.test.ts  # Filter formatting tests
+    └── lib/
+        └── session.test.ts      # filterMessages unit tests
+```
+
+**Structure Decision**: Single project structure following existing patterns. Filter logic added to lib layer (`filterMessages` function), consumed by CLI layer (`view` command with `--only` option).
+
+## Complexity Tracking
+
+No violations. Feature adds minimal complexity:
+- One new CLI option
+- One new library function
+- One new type definition

--- a/specs/003-message-type-filter/quickstart.md
+++ b/specs/003-message-type-filter/quickstart.md
@@ -1,0 +1,228 @@
+# Quickstart: Message Type Filter
+
+**Feature**: 003-message-type-filter
+**Date**: 2026-01-12
+
+## Overview
+
+This guide helps developers quickly understand and implement the message type filter feature.
+
+## What We're Building
+
+A `--only` option for the `cch view` command that filters displayed messages by type:
+
+```bash
+# Before: Shows all 50 messages
+cch view 0
+
+# After: Shows only your 8 questions
+cch view 0 --only user
+```
+
+## Key Files to Modify
+
+| File | Purpose | Changes |
+|------|---------|---------|
+| `src/lib/types.ts` | Type definitions | Add `FilterableMessageType`, `MessageFilterOptions` |
+| `src/lib/session.ts` | Core logic | Add `filterMessages()`, `classifyMessage()` |
+| `src/lib/index.ts` | Exports | Export new types and functions |
+| `src/cli/commands/view.ts` | CLI command | Add `--only` option, validation, integration |
+| `src/cli/formatters/session.ts` | Output formatting | Update header to show filtered count |
+
+## Implementation Steps
+
+### Step 1: Add Types (src/lib/types.ts)
+
+```typescript
+// Add near other type definitions
+export type FilterableMessageType = 'user' | 'assistant' | 'tool' | 'thinking' | 'error';
+
+export interface MessageFilterOptions {
+  only?: FilterableMessageType[];
+}
+
+export const VALID_FILTER_TYPES: readonly FilterableMessageType[] = [
+  'user', 'assistant', 'tool', 'thinking', 'error'
+] as const;
+```
+
+### Step 2: Add Filter Logic (src/lib/session.ts)
+
+```typescript
+import type { Message, FilterableMessageType, MessageFilterOptions } from './types.js';
+
+export function classifyMessage(message: Message): FilterableMessageType[] {
+  const types: FilterableMessageType[] = [];
+
+  if (message.type === 'user') {
+    // Check for error results
+    if (Array.isArray(message.content)) {
+      const hasError = message.content.some(
+        item => item.type === 'tool_result' && item.is_error
+      );
+      if (hasError) types.push('error');
+      // Pure tool results are excluded (shown inline with tool calls)
+      if (!message.content.every(item => item.type === 'tool_result')) {
+        types.push('user');
+      }
+    } else {
+      types.push('user');
+    }
+  }
+
+  if (message.type === 'assistant') {
+    for (const item of message.content) {
+      if (item.type === 'text') types.push('assistant');
+      if (item.type === 'tool_use') types.push('tool');
+      if (item.type === 'thinking') types.push('thinking');
+    }
+  }
+
+  return [...new Set(types)]; // Deduplicate
+}
+
+export function filterMessages(
+  messages: Message[],
+  options?: MessageFilterOptions
+): Message[] {
+  // No filter = return all displayable messages
+  if (!options?.only || options.only.length === 0) {
+    return messages.filter(m => m.type === 'user' || m.type === 'assistant');
+  }
+
+  return messages.filter(message => {
+    const types = classifyMessage(message);
+    return types.some(t => options.only!.includes(t));
+  });
+}
+```
+
+### Step 3: Export from Library (src/lib/index.ts)
+
+```typescript
+// Add to existing exports
+export type { FilterableMessageType, MessageFilterOptions } from './types.js';
+export { VALID_FILTER_TYPES } from './types.js';
+export { filterMessages, classifyMessage } from './session.js';
+```
+
+### Step 4: Add CLI Option (src/cli/commands/view.ts)
+
+```typescript
+import { VALID_FILTER_TYPES, filterMessages } from '../../lib/index.js';
+import type { FilterableMessageType } from '../../lib/index.js';
+
+// Add to ViewOptions type
+type ViewOptions = GlobalOptions & {
+  only?: string;
+};
+
+// Add validation function
+function parseFilterTypes(input: string): FilterableMessageType[] {
+  const types = input.split(',').map(t => t.trim().toLowerCase());
+  for (const type of types) {
+    if (!VALID_FILTER_TYPES.includes(type as FilterableMessageType)) {
+      throw new Error(
+        `Invalid filter type '${type}'. Valid types: ${VALID_FILTER_TYPES.join(', ')}`
+      );
+    }
+  }
+  return types as FilterableMessageType[];
+}
+
+// In registerViewCommand, add option
+program
+  .command('view <session>')
+  .description("View a session's contents")
+  .option('-o, --only <types>', 'Filter by message type (user,assistant,tool,thinking,error)')
+  .action(...)
+
+// In executeView, apply filter
+const session = await getSession(sessionRef, libConfig);
+const filteredMessages = options.only
+  ? filterMessages(session.messages, { only: parseFilterTypes(options.only) })
+  : session.messages;
+```
+
+### Step 5: Update Formatter (src/cli/formatters/session.ts)
+
+```typescript
+// Update formatSession signature
+export function formatSession(
+  session: Session,
+  options?: { filteredCount?: number }
+): string {
+  // In header, show filtered count if applicable
+  if (options?.filteredCount !== undefined) {
+    lines.push(`Messages: ${options.filteredCount} (filtered from ${session.messageCount})`);
+  } else {
+    lines.push(`Messages: ${session.messageCount}`);
+  }
+  // ... rest of formatting
+}
+```
+
+## Testing
+
+### Unit Tests
+
+```typescript
+// tests/unit/lib/session.test.ts
+describe('classifyMessage', () => {
+  it('classifies user messages', () => {
+    const msg = { type: 'user', content: 'Hello' };
+    expect(classifyMessage(msg)).toEqual(['user']);
+  });
+
+  it('classifies assistant with tool_use', () => {
+    const msg = {
+      type: 'assistant',
+      content: [{ type: 'tool_use', name: 'Read', input: {} }]
+    };
+    expect(classifyMessage(msg)).toContain('tool');
+  });
+});
+
+describe('filterMessages', () => {
+  it('filters to user messages only', () => {
+    const messages = [userMsg, assistantMsg, toolMsg];
+    const filtered = filterMessages(messages, { only: ['user'] });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].type).toBe('user');
+  });
+});
+```
+
+### Integration Tests
+
+```typescript
+// tests/integration/cli/view.test.ts
+describe('view --only', () => {
+  it('filters to user messages', async () => {
+    const result = await runCli(['view', '0', '--only', 'user']);
+    expect(result.stdout).toContain('USER');
+    expect(result.stdout).not.toContain('ASSISTANT');
+  });
+
+  it('shows error for invalid filter', async () => {
+    const result = await runCli(['view', '0', '--only', 'invalid']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Invalid filter type');
+  });
+});
+```
+
+## Checklist
+
+- [ ] Types added to `src/lib/types.ts`
+- [ ] `classifyMessage()` implemented in `src/lib/session.ts`
+- [ ] `filterMessages()` implemented in `src/lib/session.ts`
+- [ ] New exports added to `src/lib/index.ts`
+- [ ] `--only` option added to view command
+- [ ] Filter validation implemented
+- [ ] Formatter updated to show filtered count
+- [ ] Unit tests for classification logic
+- [ ] Unit tests for filter function
+- [ ] Integration tests for CLI
+- [ ] Help text updated
+- [ ] All existing tests still pass

--- a/specs/003-message-type-filter/research.md
+++ b/specs/003-message-type-filter/research.md
@@ -1,0 +1,164 @@
+# Research: Message Type Filter
+
+**Feature**: 003-message-type-filter
+**Date**: 2026-01-12
+
+## Overview
+
+This document captures research findings for implementing the message type filter feature. No NEEDS CLARIFICATION items were identified in the technical context - the existing codebase provides all necessary patterns and structures.
+
+## Research Areas
+
+### 1. Existing Type System Analysis
+
+**Decision**: Use existing structured types for message classification
+
+**Rationale**: The codebase already has well-defined types in `src/lib/types.ts` that exactly match the filter requirements:
+
+- `MessageType`: `'user' | 'assistant' | 'summary' | 'file-history-snapshot'`
+- `AssistantContent`: `TextContent | ToolUseContent | ThinkingContent`
+- `ToolResultContent`: Has `is_error?: boolean` flag for error detection
+
+**Alternatives Considered**:
+- Text-based pattern matching (e.g., `[Tool:` prefix): Rejected - fragile, already have structured types
+- Adding new message types: Rejected - existing types are sufficient
+
+### 2. Filter Implementation Location
+
+**Decision**: Implement filter function in `src/lib/session.ts`, apply in `src/cli/formatters/session.ts`
+
+**Rationale**:
+- Library-first architecture (Constitution Principle IV)
+- Existing `formatSession` function already iterates messages - natural integration point
+- Filter logic reusable for JSON output mode
+
+**Alternatives Considered**:
+- Filter in CLI layer only: Rejected - violates library-first principle
+- Filter during session loading: Rejected - adds complexity, better to filter at display time
+
+### 3. CLI Option Pattern
+
+**Decision**: Use `--only <type>` with comma-separated values
+
+**Rationale**:
+- Follows existing CLI patterns in the codebase
+- Commander.js supports custom option parsing easily
+- `--only` is intuitive and common in CLI tools (e.g., `npm audit --only=prod`)
+
+**Alternatives Considered**:
+- `--filter <type>`: More generic but less clear intent
+- `--type <type>`: Ambiguous with existing `type` fields in data
+- `--show <type>`: Conflicts with potential future "show" subcommand
+
+### 4. Content Block Classification Logic
+
+**Decision**: Classify messages based on content block types present
+
+**Rationale**: Based on analysis of `src/lib/types.ts` and `src/cli/formatters/session.ts`:
+
+| Filter | Classification Rule |
+|--------|---------------------|
+| `user` | `message.type === 'user'` AND NOT purely tool results |
+| `assistant` | `message.type === 'assistant'` AND has `TextContent` blocks |
+| `tool` | `message.type === 'assistant'` AND has `ToolUseContent` blocks |
+| `thinking` | `message.type === 'assistant'` AND has `ThinkingContent` blocks |
+| `error` | `message.type === 'user'` AND has `ToolResultContent` with `is_error: true` |
+
+**Key Insight**: An assistant message can have multiple content block types. Per spec clarification (FR-010), include entire message if ANY block matches.
+
+**Alternatives Considered**:
+- Separate error from tool results: Current approach - errors are tool results with `is_error` flag
+- Include all user messages for `error` filter: Rejected - only messages containing actual errors should match
+
+### 5. Empty Result Handling
+
+**Decision**: Display informative message instead of empty output
+
+**Rationale**:
+- Better UX than silent empty output
+- Consistent with CLI best practices
+- Helps users understand their filter matched nothing
+
+**Message Format**: `No messages match filter: <filter-types>`
+
+### 6. Invalid Filter Handling
+
+**Decision**: Display error with valid options list
+
+**Rationale**:
+- Immediate feedback on user error
+- Educational - shows available options
+- Exit code indicates error (non-zero)
+
+**Error Format**: `Invalid filter type '<invalid>'. Valid types: user, assistant, tool, thinking, error`
+
+## Integration Points
+
+### Files to Modify
+
+1. **src/lib/types.ts**
+   - Add `MessageTypeFilter` type alias
+   - Add `FilterableMessageType` union type
+
+2. **src/lib/session.ts**
+   - Add `filterMessages(messages: Message[], filter: MessageTypeFilter[]): Message[]`
+   - Add `classifyMessage(message: Message): FilterableMessageType[]`
+
+3. **src/lib/index.ts**
+   - Export new types and functions
+
+4. **src/cli/commands/view.ts**
+   - Add `--only <types>` option
+   - Parse comma-separated values
+   - Validate filter types
+   - Pass filter to formatter
+
+5. **src/cli/formatters/session.ts**
+   - Modify `formatSession` to accept optional filter
+   - Apply filter before message iteration
+
+6. **src/cli/utils/config.ts** (optional)
+   - Add filter validation utility
+
+### Existing Patterns to Follow
+
+From `src/cli/commands/view.ts`:
+```typescript
+// Option pattern (existing)
+.option('-j, --json', 'Output as JSON')
+.option('-f, --full', 'Disable paging')
+
+// New option follows same pattern
+.option('-o, --only <types>', 'Filter by message type (user,assistant,tool,thinking,error)')
+```
+
+From `src/cli/formatters/session.ts`:
+```typescript
+// Existing message classification (to reuse)
+function isToolResultMessage(msg: UserMessage): boolean
+// Existing content type checks (to extend)
+if (item.type === 'text') { ... }
+if (item.type === 'tool_use') { ... }
+if (item.type === 'thinking') { ... }
+```
+
+## Performance Considerations
+
+- Filter applied at display time (O(n) where n = message count)
+- No additional file I/O or parsing required
+- Expected performance: <100ms for 1000 messages
+- Meets SC-001: Filter 100+ message session in under 1 second
+
+## Test Strategy
+
+### Unit Tests
+- `filterMessages` with each filter type
+- `filterMessages` with multiple filter types
+- `classifyMessage` for each message/content type
+- Edge cases: empty messages, mixed content
+
+### Integration Tests
+- `cch view 0 --only user` produces expected output
+- `cch view 0 --only tool,thinking` combines filters
+- `cch view 0 --only invalid` shows error
+- `cch view 0 --only user --json` works with JSON output

--- a/specs/003-message-type-filter/spec.md
+++ b/specs/003-message-type-filter/spec.md
@@ -1,0 +1,160 @@
+# Feature Specification: Message Type Filter
+
+**Feature Branch**: `003-message-type-filter`
+**Created**: 2026-01-12
+**Status**: Draft
+**Input**: User description: "Add message type filter to show command - filter by tool calls, user messages, or assistant responses"
+
+## Clarifications
+
+### Session 2026-01-11
+
+- Q: Should thinking blocks and error messages be separate filter types or grouped with assistant/tool? → A: Add `thinking` and `error` as additional filter types (5 types total: user, assistant, tool, thinking, error)
+
+### Session 2026-01-12
+
+- Q: How are message types detected - text markers or structured data? → A: Use structured data types from existing type system (MessageType, AssistantContent subtypes, is_error flag)
+- Q: When filtering, how should mixed-content messages (e.g., text + tool_use) be handled? → A: Include entire message if ANY content block matches the filter
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter to User Messages Only (Priority: P1)
+
+As a user reviewing a long chat session, I want to see only my own messages so I can quickly review what questions I asked without scrolling through lengthy AI responses and tool outputs.
+
+**Why this priority**: This is the most common use case - users often want to see just their prompts to understand the conversation flow or copy their questions for reuse.
+
+**Independent Test**: Can be tested by running `cch view 1 --only user` and verifying only user messages appear in output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with mixed user, assistant, and tool messages, **When** I run `view <index> --only user`, **Then** I see only messages from role "user" with their timestamps
+2. **Given** a session with no user messages (edge case), **When** I run `view <index> --only user`, **Then** I see an informative message indicating no matching messages
+
+---
+
+### User Story 2 - Filter to Tool Calls Only (Priority: P1)
+
+As a developer debugging a session, I want to see only the tool calls (file reads, writes, terminal commands) so I can understand what actions the AI took without reading through explanations.
+
+**Why this priority**: Equally important as user filter - developers frequently need to audit what operations were performed.
+
+**Independent Test**: Can be tested by running `cch view 1 --only tool` and verifying only tool call messages appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with tool calls, **When** I run `view <index> --only tool`, **Then** I see only messages containing tool operations with file paths and parameters
+2. **Given** a session with no tool calls, **When** I run `view <index> --only tool`, **Then** I see an informative message indicating no matching messages
+
+---
+
+### User Story 3 - Filter to Assistant Responses Only (Priority: P2)
+
+As a user, I want to see only the AI assistant's explanatory responses (excluding tool calls and thinking) so I can review the actual answers and guidance provided.
+
+**Why this priority**: Useful for reviewing AI explanations without the noise of tool outputs, but slightly less common than filtering to user prompts or tool calls.
+
+**Independent Test**: Can be tested by running `cch view 1 --only assistant` and verifying only assistant text responses appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with assistant responses, **When** I run `view <index> --only assistant`, **Then** I see only assistant explanatory text (not tool calls, not thinking blocks)
+2. **Given** a session where all assistant messages are tool calls, **When** I run `view <index> --only assistant`, **Then** I see an informative message indicating no matching messages
+
+---
+
+### User Story 4 - Filter with Multiple Types (Priority: P2)
+
+As a user, I want to combine multiple filters so I can see exactly the message types relevant to my review (e.g., user messages and tool calls together, excluding verbose assistant explanations).
+
+**Why this priority**: Provides flexibility for advanced users who need specific combinations.
+
+**Independent Test**: Can be tested by running `cch view 1 --only user,tool` and verifying both user and tool messages appear but assistant responses are excluded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with all message types, **When** I run `view <index> --only user,tool`, **Then** I see user messages and tool calls but not assistant text responses
+2. **Given** I specify all five types `--only user,assistant,tool,thinking,error`, **When** the command runs, **Then** behavior is equivalent to no filter (all messages shown)
+
+---
+
+### User Story 5 - Filter to Thinking Blocks (Priority: P3)
+
+As a developer, I want to see only thinking blocks so I can understand the AI's reasoning process separately from its responses.
+
+**Why this priority**: Lower priority as thinking blocks are less frequently reviewed in isolation.
+
+**Independent Test**: Can be tested by running `cch view 1 --only thinking` and verifying only thinking block messages appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with thinking blocks, **When** I run `view <index> --only thinking`, **Then** I see only thinking block content
+2. **Given** a session with no thinking blocks, **When** I run `view <index> --only thinking`, **Then** I see an informative message indicating no matching messages
+
+---
+
+### User Story 6 - Filter to Error Messages (Priority: P3)
+
+As a developer debugging issues, I want to see only error messages so I can quickly identify what went wrong during a session.
+
+**Why this priority**: Lower priority but valuable for troubleshooting sessions.
+
+**Independent Test**: Can be tested by running `cch view 1 --only error` and verifying only error messages appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with error messages, **When** I run `view <index> --only error`, **Then** I see only error message content
+2. **Given** a session with no errors, **When** I run `view <index> --only error`, **Then** I see an informative message indicating no matching messages
+
+---
+
+### Edge Cases
+
+- What happens when filter value is invalid (e.g., `--only invalid`)? Display error message listing valid options.
+- What happens when filter results in zero messages? Display informative message rather than empty output.
+- How does filter interact with existing display options (`--json`)? Filters apply first, then display options format the filtered results.
+- How does filter work with `--json` output? JSON output includes only filtered messages.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support `--only <type>` option on the `view` command to filter displayed messages
+- **FR-002**: System MUST accept the following filter values: `user`, `assistant`, `tool`, `thinking`, `error`
+- **FR-003**: System MUST support comma-separated multiple values (e.g., `--only user,tool`)
+- **FR-004**: System MUST display an error with valid options when an invalid filter value is provided
+- **FR-005**: System MUST display an informative message when filter results in zero messages
+- **FR-006**: System MUST apply filters before existing display formatting options
+- **FR-007**: System MUST support the `--only` filter in JSON output mode
+- **FR-008**: System MUST preserve message ordering and timestamps in filtered output
+- **FR-009**: The library API MUST expose filter functionality through the session retrieval options
+- **FR-010**: System MUST include entire message when ANY content block matches the filter (mixed-content messages show all blocks)
+
+### Message Type Classification
+
+- **User messages** (`user`): Messages with `type: 'user'` in the data structure
+- **Tool calls** (`tool`): Assistant messages containing `content` blocks with `type: 'tool_use'`
+- **Assistant responses** (`assistant`): Assistant messages with `type: 'text'` content blocks (excluding tool_use and thinking blocks)
+- **Thinking blocks** (`thinking`): Assistant messages containing `content` blocks with `type: 'thinking'`
+- **Error messages** (`error`): User messages containing tool results with `is_error: true` flag
+
+### Key Entities
+
+- **MessageFilter**: The filter criteria specifying which message types to include (user, assistant, tool, thinking, error)
+- **FilteredSession**: A session where messages have been filtered according to the specified criteria
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can filter a 100+ message session to show only their messages in under 1 second
+- **SC-002**: Filter output correctly excludes 100% of non-matching message types
+- **SC-003**: All existing tests continue to pass after adding filter functionality
+- **SC-004**: Library API users can filter messages programmatically with the same options as CLI
+
+## Assumptions
+
+- Message type classification uses the existing structured type system (MessageType, AssistantContent, ToolResultContent)
+- Mixed-content filtering: when an assistant message contains multiple content block types (e.g., text + tool_use), the entire message is included if any block matches the filter
+- The filter is applied at display time, not at the database query level (simpler implementation, adequate performance)
+- The command name is `view` (not `show`) based on the existing CLI structure in CLAUDE.md

--- a/specs/003-message-type-filter/tasks.md
+++ b/specs/003-message-type-filter/tasks.md
@@ -1,0 +1,257 @@
+# Tasks: Message Type Filter
+
+**Input**: Design documents from `/specs/003-message-type-filter/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested in spec. Tasks focus on implementation only.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. Due to shared infrastructure, stories US1-US6 are grouped by implementation layer rather than individual filters.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/`, `tests/` at repository root
+- Using existing structure from plan.md
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new setup required - this feature extends existing infrastructure
+
+- [x] T001 Verify existing project structure matches plan.md expectations in src/lib/ and src/cli/
+
+**Checkpoint**: Structure verified - proceed to foundational work
+
+---
+
+## Phase 2: Foundational (Library Types & Core Functions)
+
+**Purpose**: Core library infrastructure that enables ALL filter types (US1-US6)
+
+**⚠️ CRITICAL**: All user story filter implementations depend on these types and functions
+
+### Types Definition
+
+- [x] T002 [P] Add `FilterableMessageType` type alias in src/lib/types.ts
+- [x] T003 [P] Add `MessageFilterOptions` interface in src/lib/types.ts
+- [x] T004 [P] Add `VALID_FILTER_TYPES` constant array in src/lib/types.ts
+
+### Core Classification Logic
+
+- [x] T005 Implement `classifyMessage(message: Message): FilterableMessageType[]` function in src/lib/session.ts
+  - Handle UserMessage → 'user' (when content is string)
+  - Handle UserMessage → 'error' (when content has ToolResultContent with is_error=true)
+  - Handle AssistantMessage → 'assistant' (when has TextContent)
+  - Handle AssistantMessage → 'tool' (when has ToolUseContent)
+  - Handle AssistantMessage → 'thinking' (when has ThinkingContent)
+  - Exclude SummaryMessage and FileHistorySnapshot
+  - Return deduplicated array of types
+
+### Core Filter Logic
+
+- [x] T006 Implement `filterMessages(messages: Message[], options?: MessageFilterOptions): Message[]` function in src/lib/session.ts
+  - Return all displayable messages when options.only is empty/undefined
+  - Filter using classifyMessage to check if ANY content block matches
+  - Preserve message ordering
+
+### Library Exports
+
+- [x] T007 Export new types and functions from src/lib/index.ts
+  - Export `FilterableMessageType`
+  - Export `MessageFilterOptions`
+  - Export `VALID_FILTER_TYPES`
+  - Export `filterMessages`
+  - Export `classifyMessage`
+
+**Checkpoint**: Foundation ready - library API complete and exported
+
+---
+
+## Phase 3: User Story 1 & 2 - Filter to User/Tool Messages (Priority: P1) 🎯 MVP
+
+**Goal**: Enable `--only user` and `--only tool` filters on the view command
+
+**Independent Test**:
+- Run `cch view 0 --only user` and verify only user messages appear
+- Run `cch view 0 --only tool` and verify only tool call messages appear
+
+### CLI Option Implementation
+
+- [x] T008 Add `--only <types>` option to view command in src/cli/commands/view.ts
+  - Add `.option('-o, --only <types>', 'Filter by message type (user,assistant,tool,thinking,error)')`
+  - Update ViewOptions type to include `only?: string`
+
+### CLI Validation
+
+- [x] T009 Implement filter type validation in src/cli/commands/view.ts
+  - Parse comma-separated values
+  - Trim whitespace from each value
+  - Validate against VALID_FILTER_TYPES
+  - Show error with valid options list for invalid types
+
+### CLI Integration
+
+- [x] T010 [US1] [US2] Integrate filterMessages into view command execution in src/cli/commands/view.ts
+  - Import filterMessages and VALID_FILTER_TYPES from lib
+  - Call filterMessages after getSession when --only is provided
+  - Pass filtered messages to formatter
+
+### Formatter Updates
+
+- [x] T011 [US1] [US2] Update formatSession to show filtered message count in src/cli/formatters/session.ts
+  - Accept optional totalCount parameter
+  - Display "Messages: X (filtered from Y)" when filter is active
+
+### JSON Output Support
+
+- [x] T012 [US1] [US2] Update formatSessionForJson to include filter metadata in src/cli/formatters/session.ts
+  - Add totalMessageCount field when filtering
+  - Add filter field showing applied filter types
+
+### Empty Result Handling
+
+- [x] T013 [US1] [US2] Add informative message for zero matching results in src/cli/commands/view.ts
+  - Display "No messages match filter: <types>" instead of empty output
+  - Exit code 0 (operation succeeded, just no matches)
+
+**Checkpoint**: User Story 1 & 2 complete - `--only user` and `--only tool` work independently
+
+---
+
+## Phase 4: User Story 3 & 4 - Filter to Assistant/Multiple Types (Priority: P2)
+
+**Goal**: Enable `--only assistant` filter and comma-separated multiple type filters
+
+**Independent Test**:
+- Run `cch view 0 --only assistant` and verify only assistant text responses appear (no tool calls)
+- Run `cch view 0 --only user,tool` and verify both types appear but not assistant
+
+### Implementation
+
+- [x] T014 [US3] Verify assistant filter excludes tool_use and thinking content in classifyMessage
+  - Assistant type should only match messages with TextContent blocks
+  - Verify mixed-content messages work correctly (e.g., text + tool_use includes entire message)
+
+- [x] T015 [US4] Verify multiple filter types work with comma-separated values
+  - Test parsing of "user,tool" → ['user', 'tool']
+  - Test that specifying all 5 types is equivalent to no filter
+  - Test whitespace trimming: " user , tool " → ['user', 'tool']
+
+**Checkpoint**: User Stories 3 & 4 complete - assistant filter and multi-type filters work
+
+---
+
+## Phase 5: User Story 5 & 6 - Filter to Thinking/Error Messages (Priority: P3)
+
+**Goal**: Enable `--only thinking` and `--only error` filters
+
+**Independent Test**:
+- Run `cch view 0 --only thinking` and verify only thinking blocks appear
+- Run `cch view 0 --only error` and verify only error tool results appear
+
+### Implementation
+
+- [x] T016 [US5] Verify thinking filter works for ThinkingContent blocks
+  - Thinking blocks should be extracted from assistant messages with type: 'thinking'
+
+- [x] T017 [US6] Verify error filter works for ToolResultContent with is_error flag
+  - Error messages are user messages containing tool results with is_error: true
+
+**Checkpoint**: All user stories complete - all 5 filter types functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalization and validation
+
+- [x] T018 Add JSDoc documentation for all new public functions in src/lib/session.ts
+- [x] T019 [P] Run existing test suite to verify no regressions
+- [x] T020 [P] Run linting and fix any issues
+- [x] T021 Validate feature works end-to-end with quickstart.md scenarios
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verification only
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all user stories
+- **User Stories 1&2 (Phase 3)**: Depends on Foundational completion
+- **User Stories 3&4 (Phase 4)**: Depends on Phase 3 (same codebase, sequential refinement)
+- **User Stories 5&6 (Phase 5)**: Depends on Phase 4 (same codebase, sequential refinement)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 & US2 (P1)**: Core filter implementation - establishes pattern for all others
+- **US3 & US4 (P2)**: Builds on US1/US2 infrastructure - verifies edge cases
+- **US5 & US6 (P3)**: Final filter types - minimal additional code
+
+### Within Each Phase
+
+- Types before functions (T002-T004 before T005-T006)
+- Library before CLI (T005-T007 before T008-T013)
+- Core functionality before polish
+
+### Parallel Opportunities
+
+**Phase 2 (Foundational)**:
+```bash
+# Can run in parallel (different types in same file section):
+T002, T003, T004  # All type definitions
+```
+
+**Phase 6 (Polish)**:
+```bash
+# Can run in parallel (independent tasks):
+T019, T020  # Tests and linting
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2 Only)
+
+1. Complete Phase 1: Setup verification
+2. Complete Phase 2: Foundational types and functions
+3. Complete Phase 3: User Stories 1 & 2
+4. **STOP and VALIDATE**: Test `--only user` and `--only tool` independently
+5. Deploy/demo if ready - core filtering works
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Library API ready
+2. Add US1 & US2 → Test independently → User/Tool filters work (MVP!)
+3. Add US3 & US4 → Test independently → Assistant/Multi-type filters work
+4. Add US5 & US6 → Test independently → Thinking/Error filters work
+5. Complete Polish → Full feature ready
+
+### Single Developer Strategy
+
+Recommended order:
+1. T001 → T002-T004 → T005 → T006 → T007 (Library complete)
+2. T008 → T009 → T010 → T011 → T012 → T013 (CLI complete, MVP ready)
+3. T014 → T015 (P2 stories)
+4. T016 → T017 (P3 stories)
+5. T018-T021 (Polish)
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent sections, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All filter types share the same infrastructure - stories grouped by priority
+- US1/US2 (P1) are MVP - stop here for minimum viable feature
+- US3-US6 extend the same codebase incrementally
+- Commit after each task or logical group
+- Stop at any checkpoint to validate independently

--- a/src/cli/commands/view.ts
+++ b/src/cli/commands/view.ts
@@ -9,6 +9,9 @@ import {
   getSession,
   isSessionNotFoundError,
   isDataNotFoundError,
+  filterMessages,
+  VALID_FILTER_TYPES,
+  type FilterableMessageType,
 } from '../../lib/index.js';
 import {
   type GlobalOptions,
@@ -24,7 +27,32 @@ import { outputWithPager } from '../formatters/pager.js';
 /**
  * View command options
  */
-type ViewOptions = GlobalOptions;
+interface ViewOptions extends GlobalOptions {
+  only?: string;
+}
+
+/**
+ * Parse and validate filter types from comma-separated string.
+ * @throws Error if any filter type is invalid
+ */
+function parseFilterTypes(input: string): FilterableMessageType[] {
+  const types = input.split(',').map((t) => t.trim().toLowerCase());
+
+  // Validate each type
+  for (const type of types) {
+    if (!type) {
+      continue; // Skip empty strings from trailing commas
+    }
+    if (!VALID_FILTER_TYPES.includes(type as FilterableMessageType)) {
+      throw new Error(
+        `Invalid filter type '${type}'. Valid types: ${VALID_FILTER_TYPES.join(', ')}`
+      );
+    }
+  }
+
+  // Filter out empty strings and return
+  return types.filter((t) => t !== '') as FilterableMessageType[];
+}
 
 /**
  * Execute the view command
@@ -49,16 +77,72 @@ async function executeView(
   const libConfig = toLibraryConfig(config);
 
   try {
+    // Parse filter types if provided
+    let filterTypes: FilterableMessageType[] | undefined;
+    if (options.only) {
+      try {
+        filterTypes = parseFilterTypes(options.only);
+      } catch (filterError) {
+        const exitCode = handleError(
+          usageError(
+            (filterError as Error).message,
+            `Usage: cch view <session> --only <types>\n\nFilter types: ${VALID_FILTER_TYPES.join(', ')}`
+          ),
+          options.json
+        );
+        process.exit(exitCode);
+      }
+    }
+
     const session = await getSession(sessionRef, libConfig);
+    const totalMessageCount = session.messages.filter(
+      (m) => m.type === 'user' || m.type === 'assistant'
+    ).length;
+
+    // Apply filter if specified
+    const filteredMessages = filterTypes
+      ? filterMessages(session.messages, { only: filterTypes })
+      : session.messages;
+
+    // Check for empty results with filter
+    if (filterTypes && filteredMessages.length === 0) {
+      if (options.json) {
+        // JSON output for empty results
+        const jsonData = formatSessionForJson(session, {
+          messages: filteredMessages,
+          filter: filterTypes,
+          totalMessageCount,
+        });
+        const commandResult = successResult(jsonData);
+        output(commandResult, true);
+      } else {
+        // Human-readable output for empty results
+        const formattedSession = formatSession(session, {
+          messages: filteredMessages,
+          filter: filterTypes,
+          totalMessageCount,
+        });
+        await outputWithPager(formattedSession, options.full);
+      }
+      return;
+    }
 
     if (options.json) {
       // JSON output
-      const jsonData = formatSessionForJson(session);
+      const jsonData = formatSessionForJson(session, filterTypes ? {
+        messages: filteredMessages,
+        filter: filterTypes,
+        totalMessageCount,
+      } : undefined);
       const commandResult = successResult(jsonData);
       output(commandResult, true);
     } else {
       // Human-readable output
-      const formattedSession = formatSession(session);
+      const formattedSession = formatSession(session, filterTypes ? {
+        messages: filteredMessages,
+        filter: filterTypes,
+        totalMessageCount,
+      } : undefined);
       await outputWithPager(formattedSession, options.full);
     }
   } catch (error) {
@@ -95,13 +179,18 @@ export function registerViewCommand(program: Command): void {
   program
     .command('view <session>')
     .description("View a session's contents")
-    .action(async (sessionArg: string) => {
+    .option(
+      '-o, --only <types>',
+      'Filter by message type (user,assistant,tool,thinking,error)'
+    )
+    .action(async (sessionArg: string, cmdOptions: { only?: string }) => {
       const globalOptions = program.opts() as GlobalOptions;
+      const options: ViewOptions = { ...globalOptions, ...cmdOptions };
 
       try {
-        await executeView(sessionArg, globalOptions);
+        await executeView(sessionArg, options);
       } catch (error) {
-        const exitCode = handleError(error, globalOptions.json);
+        const exitCode = handleError(error, options.json);
         process.exit(exitCode);
       }
     });

--- a/src/cli/formatters/session.ts
+++ b/src/cli/formatters/session.ts
@@ -15,7 +15,20 @@ import type {
   TextContent,
   ThinkingContent,
   ToolResultContent,
+  FilterableMessageType,
 } from '../../lib/index.js';
+
+/**
+ * Options for formatting session with filter applied
+ */
+export interface SessionFormatOptions {
+  /** Filtered messages to display (instead of session.messages) */
+  messages: Message[];
+  /** Filter types that were applied */
+  filter: FilterableMessageType[];
+  /** Total message count before filtering */
+  totalMessageCount: number;
+}
 
 /**
  * Map of tool_use_id to tool result content
@@ -245,13 +258,22 @@ function separator(): string {
 /**
  * Format session header
  */
-function formatSessionHeader(session: Session): string {
+function formatSessionHeader(
+  session: Session,
+  options?: SessionFormatOptions
+): string {
   const lines = [
     `Session: ${session.id}`,
     `Project: ${session.projectPath}`,
     `Started: ${formatDate(session.timestamp)}`,
-    `Messages: ${session.messageCount}`,
   ];
+
+  // Show filtered message count if filter is applied
+  if (options) {
+    lines.push(`Messages: ${options.messages.length} (filtered from ${options.totalMessageCount})`);
+  } else {
+    lines.push(`Messages: ${session.messageCount}`);
+  }
 
   if (session.gitBranch) {
     lines.push(`Branch: ${session.gitBranch}`);
@@ -272,21 +294,37 @@ function formatSessionHeader(session: Session): string {
  * content is shown inline with the tool call.
  *
  * @param session - Full session object with messages
+ * @param options - Optional format options for filtered output
  * @returns Formatted session string
  */
-export function formatSession(session: Session): string {
+export function formatSession(
+  session: Session,
+  options?: SessionFormatOptions
+): string {
   const parts: string[] = [];
 
-  // Build tool result map for pairing
+  // Use filtered messages if provided, otherwise use session messages
+  const messagesToFormat = options?.messages ?? session.messages;
+
+  // Build tool result map for pairing (use all session messages for complete context)
   const toolResults = buildToolResultMap(session.messages);
 
   // Header
-  parts.push(formatSessionHeader(session));
+  parts.push(formatSessionHeader(session, options));
   parts.push('');
   parts.push(separator());
 
+  // Handle empty filtered results
+  if (options && messagesToFormat.length === 0) {
+    parts.push('');
+    parts.push(`No messages match filter: ${options.filter.join(', ')}`);
+    parts.push('');
+    parts.push(separator());
+    return parts.join('\n');
+  }
+
   // Messages
-  for (const msg of session.messages) {
+  for (const msg of messagesToFormat) {
     // Skip summary and file-history-snapshot messages
     if (msg.type !== 'user' && msg.type !== 'assistant') {
       continue;
@@ -314,9 +352,32 @@ export function formatSession(session: Session): string {
 }
 
 /**
- * Format session for JSON output
- * Returns the session as-is since it's already structured
+ * JSON output type for filtered session
  */
-export function formatSessionForJson(session: Session): Session {
-  return session;
+export interface FilteredSessionJson extends Omit<Session, 'messages'> {
+  messages: Message[];
+  filter?: FilterableMessageType[];
+  totalMessageCount?: number;
+}
+
+/**
+ * Format session for JSON output
+ * Returns the session with optional filter metadata
+ */
+export function formatSessionForJson(
+  session: Session,
+  options?: SessionFormatOptions
+): Session | FilteredSessionJson {
+  if (!options) {
+    return session;
+  }
+
+  // Return session with filtered messages and metadata
+  return {
+    ...session,
+    messages: options.messages,
+    messageCount: options.messages.length,
+    filter: options.filter,
+    totalMessageCount: options.totalMessageCount,
+  };
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -52,7 +52,13 @@ export type {
   MigrateWorkspaceConfig,
   MigrateError,
   MigrateResult,
+
+  // Message Filtering
+  FilterableMessageType,
+  MessageFilterOptions,
 } from './types.js';
+
+export { VALID_FILTER_TYPES } from './types.js';
 
 // =============================================================================
 // Error Classes and Type Guards
@@ -71,7 +77,13 @@ export {
 // Session Functions
 // =============================================================================
 
-export { listSessions, getSession, getAgentSession } from './session.js';
+export {
+  listSessions,
+  getSession,
+  getAgentSession,
+  classifyMessage,
+  filterMessages,
+} from './session.js';
 
 // =============================================================================
 // Search Functions

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -6,7 +6,18 @@
 
 import { readdir, stat } from 'fs/promises';
 import { join } from 'path';
-import type { LibraryConfig, SessionSummary, Session, Message, PaginatedResult } from './types.js';
+import type {
+  LibraryConfig,
+  SessionSummary,
+  Session,
+  Message,
+  PaginatedResult,
+  FilterableMessageType,
+  MessageFilterOptions,
+  UserMessage,
+  AssistantMessage,
+  ToolResultContent,
+} from './types.js';
 import { resolveConfig, paginate, createPagination, type ResolvedConfig } from './config.js';
 import {
   getProjectsPath,
@@ -406,4 +417,137 @@ export async function getAgentSession(agentId: string, config?: LibraryConfig): 
     agentIds: [],
     messages,
   };
+}
+
+// =============================================================================
+// Message Filtering
+// =============================================================================
+
+/**
+ * Classify a message into filterable types.
+ *
+ * @param message - Message to classify
+ * @returns Array of applicable filter types for this message
+ *
+ * @remarks
+ * A message can have multiple classifications (e.g., an assistant message
+ * with both text and tool_use content will return ['assistant', 'tool']).
+ *
+ * Returns empty array for non-displayable messages (summary, file-history-snapshot).
+ *
+ * @example
+ * ```typescript
+ * import { classifyMessage } from 'claude-code-history';
+ *
+ * const types = classifyMessage(message);
+ * // For user message: ['user']
+ * // For assistant with text + tool: ['assistant', 'tool']
+ * // For user with error result: ['error']
+ * ```
+ */
+export function classifyMessage(message: Message): FilterableMessageType[] {
+  const types: FilterableMessageType[] = [];
+
+  // Skip non-displayable message types
+  if (message.type === 'summary' || message.type === 'file-history-snapshot') {
+    return types;
+  }
+
+  if (message.type === 'user') {
+    const userMsg = message as UserMessage;
+
+    // Check if content is a string (regular user message)
+    if (typeof userMsg.content === 'string') {
+      types.push('user');
+    } else if (Array.isArray(userMsg.content)) {
+      // Check for error results in tool result content
+      const toolResults = userMsg.content as ToolResultContent[];
+      const hasError = toolResults.some((item) => item.type === 'tool_result' && item.is_error);
+
+      if (hasError) {
+        types.push('error');
+      }
+
+      // Only add 'user' if not purely tool results (tool results are shown inline with tool calls)
+      const isPurelyToolResults = toolResults.every((item) => item.type === 'tool_result');
+      if (!isPurelyToolResults) {
+        types.push('user');
+      }
+    }
+  }
+
+  if (message.type === 'assistant') {
+    const assistantMsg = message as AssistantMessage;
+
+    for (const item of assistantMsg.content) {
+      if (item.type === 'text') {
+        if (!types.includes('assistant')) {
+          types.push('assistant');
+        }
+      }
+      if (item.type === 'tool_use') {
+        if (!types.includes('tool')) {
+          types.push('tool');
+        }
+      }
+      if (item.type === 'thinking') {
+        if (!types.includes('thinking')) {
+          types.push('thinking');
+        }
+      }
+    }
+  }
+
+  return types;
+}
+
+/**
+ * Filter messages by type.
+ *
+ * @param messages - Array of messages to filter
+ * @param options - Filter options specifying which types to include
+ * @returns Filtered array of messages
+ *
+ * @remarks
+ * - If `options.only` is empty or undefined, returns all displayable messages
+ * - Messages with mixed content (e.g., text + tool_use) are included
+ *   if ANY content block matches the filter
+ * - Order and timestamps are preserved
+ * - Summary and file-history-snapshot messages are always excluded
+ *
+ * @example
+ * ```typescript
+ * import { filterMessages } from 'claude-code-history';
+ *
+ * // Filter to only user messages
+ * const userMessages = filterMessages(session.messages, { only: ['user'] });
+ *
+ * // Filter to tools and errors
+ * const toolsAndErrors = filterMessages(session.messages, { only: ['tool', 'error'] });
+ *
+ * // No filter (returns all displayable messages)
+ * const allMessages = filterMessages(session.messages, {});
+ * ```
+ */
+export function filterMessages(
+  messages: Message[],
+  options?: MessageFilterOptions
+): Message[] {
+  // First, filter out non-displayable messages (summary, file-history-snapshot)
+  const displayableMessages = messages.filter(
+    (m) => m.type === 'user' || m.type === 'assistant'
+  );
+
+  // If no filter specified or empty filter, return all displayable messages
+  if (!options?.only || options.only.length === 0) {
+    return displayableMessages;
+  }
+
+  // Filter messages based on classification
+  const filterTypes = options.only;
+  return displayableMessages.filter((message) => {
+    const messageTypes = classifyMessage(message);
+    // Include message if ANY of its types match the filter
+    return messageTypes.some((type) => filterTypes.includes(type));
+  });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -180,6 +180,44 @@ export interface ToolResultContent {
 }
 
 // =============================================================================
+// Message Filtering Types
+// =============================================================================
+
+/**
+ * Message types that can be filtered in session views.
+ *
+ * @remarks
+ * - `user`: User-authored messages (questions, prompts)
+ * - `assistant`: AI text responses (excludes tool calls and thinking)
+ * - `tool`: Tool invocations (Read, Write, Bash, etc.)
+ * - `thinking`: AI reasoning/thinking blocks
+ * - `error`: Tool results with errors
+ */
+export type FilterableMessageType = 'user' | 'assistant' | 'tool' | 'thinking' | 'error';
+
+/**
+ * Options for filtering messages in a session.
+ */
+export interface MessageFilterOptions {
+  /**
+   * Message types to include.
+   * Empty array or undefined means include all types.
+   */
+  only?: FilterableMessageType[];
+}
+
+/**
+ * Array of valid filter type strings for validation.
+ */
+export const VALID_FILTER_TYPES: readonly FilterableMessageType[] = [
+  'user',
+  'assistant',
+  'tool',
+  'thinking',
+  'error',
+] as const;
+
+// =============================================================================
 // Supporting Types
 // =============================================================================
 


### PR DESCRIPTION
Add --only option to filter messages by type (user, assistant, tool, thinking, error). Supports comma-separated multiple types.

Library changes:
- Add FilterableMessageType, MessageFilterOptions, VALID_FILTER_TYPES
- Add classifyMessage() and filterMessages() functions
- Export new types and functions from index.ts

CLI changes:
- Add -o, --only <types> option to view command
- Update formatSession to show filtered count
- Update formatSessionForJson to include filter metadata
- Add validation and helpful error messages for invalid filters