### PR TITLE
010 stream session parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-01
 ## Active Technologies
 - TypeScript 5.x with strict mode enabled, running on Node.js 20+ + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`) (008-agent-session-linking)
 - Local Claude Code JSONL session files under `~/.claude/projects/`, including both flat `agent-*.jsonl` files and nested `<main-session>/subagents/agent-*.jsonl` files (008-agent-session-linking)
+- Local Claude Code JSONL session files under `~/.claude/projects/`, including flat `agent-*.jsonl` files and nested `<main-session>/subagents/agent-*.jsonl` files (010-stream-session-parsing)
 
 - TypeScript 5.x with strict mode enabled + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`) (007-support-progress-messages)
 
@@ -24,10 +25,10 @@ npm test && npm run lint
 TypeScript 5.x with strict mode enabled: Follow standard conventions
 
 ## Recent Changes
+- 010-stream-session-parsing: Added TypeScript 5.x with strict mode enabled, running on Node.js 20+ + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`)
 - 009-full-content-lib: Added TypeScript 5.x with strict mode enabled, running on Node.js 20+ + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`)
 - 008-agent-session-linking: Added TypeScript 5.x with strict mode enabled, running on Node.js 20+ + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`)
 
-- 007-support-progress-messages: Added TypeScript 5.x with strict mode enabled + Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,14 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/', 'build/', 'node_modules/', 'coverage/', '*.config.js', '*.config.ts'],
+    ignores: [
+      'dist/',
+      'build/',
+      'node_modules/',
+      'coverage/',
+      '*.config.js',
+      '*.config.ts',
+      '*.min.js',
+    ],
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-history",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-history",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-history",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "CLI and library for browsing, searching, exporting, and managing Claude Code chat history",
   "type": "module",
   "main": "./dist/lib/index.js",

--- a/specs/010-stream-session-parsing/checklists/requirements.md
+++ b/specs/010-stream-session-parsing/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Memory-Safe Session Listing and Detail Loading
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-04-03; no checklist failures or clarification markers remain.

--- a/specs/010-stream-session-parsing/contracts/cli-interface.md
+++ b/specs/010-stream-session-parsing/contracts/cli-interface.md
@@ -1,0 +1,94 @@
+# CLI Interface Contract: Memory-Safe Session Listing and Detail Loading
+
+**Feature**: 010-stream-session-parsing  
+**Date**: 2026-04-03
+
+## Overview
+
+This contract documents the user-visible `cch list` behavior after summary rows gain fallback preview text from memory-safe library parsing.
+
+## Command: `list`
+
+### Syntax
+
+```bash
+cch list [options]
+```
+
+No new flags are introduced.
+
+### Human-Readable Output
+
+```bash
+cch list
+```
+
+**Behavioral Contract**:
+- Main-session rows, sorting, workspace filtering, and pagination semantics remain unchanged.
+- The `SUMMARY` column displays:
+  - explicit `summary` when present,
+  - otherwise derived `preview`,
+  - otherwise `(No summary)`.
+- Table column truncation remains a display concern only; the library still exposes the full bounded `preview` value in summary objects.
+- Session listing must not fail with memory exhaustion on the planned large-fixture workload at or below the 512 MiB ceiling.
+
+### JSON Output
+
+```bash
+cch list --json
+```
+
+**Behavioral Contract**:
+- Each row includes the additive `preview` field from `SessionSummary`.
+- Existing fields, pagination shape, and index assignment remain unchanged.
+
+### Example JSON Row
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "index": 0,
+      "id": "11111111-1111-1111-1111-111111111111",
+      "projectPath": "/tmp/project",
+      "gitBranch": "main",
+      "summary": null,
+      "preview": "Investigate the parser memory spike in large Claude transcripts...",
+      "timestamp": "2026-04-03T10:00:00.000Z",
+      "lastActivityAt": "2026-04-03T10:05:00.000Z",
+      "messageCount": 42,
+      "agentIds": ["abc123"],
+      "unresolvedAgentIds": []
+    }
+  ]
+}
+```
+
+## Command: `view`
+
+### Syntax
+
+```bash
+cch view <session> [options]
+```
+
+### Behavior
+
+- User-visible output and JSON payload shape remain unchanged except for the additive inherited `preview` field on session objects returned by the library and serialized by existing JSON helpers.
+- A single `cch view <session>` request must not perform duplicate full-file parsing of the same target transcript.
+- Full message rendering remains complete and non-destructive.
+
+## Option Interactions
+
+| Command | Behavior |
+|---------|----------|
+| `cch list` | Uses `summary`, then `preview`, then `(No summary)` for the SUMMARY column |
+| `cch list --json` | Includes additive `preview` per row |
+| `cch view <session>` | Retrieves full messages and metadata from one transcript pass |
+| `cch view <agent-id>` | Keeps existing agent lookup semantics and one-pass detail parsing |
+
+## Out of Scope
+
+- No `vibe-history` consumer code changes are included in this feature.
+- No new CLI flags or subcommands are added.

--- a/specs/010-stream-session-parsing/contracts/cli-interface.md
+++ b/specs/010-stream-session-parsing/contracts/cli-interface.md
@@ -25,12 +25,13 @@ cch list
 
 **Behavioral Contract**:
 - Main-session rows, sorting, workspace filtering, and pagination semantics remain unchanged.
+- Agent sessions also appear as top-level rows in `cch list`.
 - The `SUMMARY` column displays:
   - explicit `summary` when present,
   - otherwise derived `preview`,
   - otherwise `(No summary)`.
 - Table column truncation remains a display concern only; the library still exposes the full bounded `preview` value in summary objects.
-- Session listing must not fail with memory exhaustion on the planned large-fixture workload at or below the 512 MiB ceiling.
+- Session listing must not fail with memory exhaustion on the planned large-fixture workload at or below the 512 MiB ceiling, and summary-only preview rendering must reduce fallback detail fetches by at least 90% versus the old untitled-session fallback flow on the same fixture.
 
 ### JSON Output
 
@@ -83,7 +84,7 @@ cch view <session> [options]
 
 | Command | Behavior |
 |---------|----------|
-| `cch list` | Uses `summary`, then `preview`, then `(No summary)` for the SUMMARY column |
+| `cch list` | Shows both main and agent sessions as top-level rows; uses `summary`, then `preview`, then `(No summary)` for the SUMMARY column |
 | `cch list --json` | Includes additive `preview` per row |
 | `cch view <session>` | Retrieves full messages and metadata from one transcript pass |
 | `cch view <agent-id>` | Keeps existing agent lookup semantics and one-pass detail parsing |

--- a/specs/010-stream-session-parsing/contracts/library-api.md
+++ b/specs/010-stream-session-parsing/contracts/library-api.md
@@ -1,0 +1,108 @@
+# Library API Contract: Memory-Safe Session Listing and Detail Loading
+
+**Feature**: 010-stream-session-parsing  
+**Date**: 2026-04-03
+
+## Overview
+
+This contract defines the additive library-facing behavior needed to expose fallback preview text in summary listing, preserve full-fidelity session details, and remove duplicate full-file parsing from one `getSession()` request.
+
+## Updated Public Types
+
+### SessionSummary
+
+```typescript
+export interface SessionSummary {
+  id: string;
+  projectPath: string;
+  gitBranch: string | null;
+  summary: string | null;
+  preview: string | null;
+  timestamp: Date;
+  lastActivityAt: Date;
+  messageCount: number;
+  agentIds: string[];
+  unresolvedAgentIds: string[];
+}
+```
+
+**Behavioral Contract**:
+- `summary` remains the explicit transcript summary/title when present.
+- `preview` is a derived fallback string from the earliest user-authored string message, capped at 200 visible characters after trimming and whitespace normalization, or `null` when no such message exists.
+- `preview` is additive and must not remove or redefine `summary`.
+- Agent link arrays remain scoped to the session represented by the summary and must stay unique and sorted.
+
+### Session
+
+```typescript
+export interface Session extends SessionSummary {
+  encodedPath: string;
+  version: string;
+  messages: Message[];
+}
+```
+
+**Behavioral Contract**:
+- Full session retrieval preserves all existing `messages`, `encodedPath`, `version`, and metadata semantics.
+- `preview` is available on detail results as inherited summary metadata and does not affect message fidelity.
+
+## Updated Functions and Behaviors
+
+### listSessions
+
+```typescript
+export async function listSessions(
+  config?: LibraryConfig
+): Promise<PaginatedResult<SessionSummary>>;
+```
+
+**Behavioral Contract**:
+- Returns one `SessionSummary` per discoverable main session, excluding agent transcripts as top-level rows.
+- Populates `preview` directly from summary parsing so consumers can render fallback labels for untitled sessions without calling `getSession()` per row.
+- Uses one-pass summary scans for compact metadata, preview, and explicit agent-link extraction, and must not retain full raw transcript arrays for every listed session.
+- Preserves existing pagination, workspace filtering, sorting, and linked/unresolved agent ID semantics.
+- Malformed non-empty JSON lines in one transcript must not abort listing of unrelated sessions; recoverable parse warnings remain internal unless surfaced by an existing caller.
+
+### getSession
+
+```typescript
+export async function getSession(
+  identifier: number | string,
+  config?: LibraryConfig
+): Promise<Session>;
+```
+
+**Behavioral Contract**:
+- Accepted identifiers and not-found/agent fallback behavior remain unchanged.
+- Returns the complete full-fidelity `messages` array and all summary metadata, including additive `preview`.
+- Must process the target transcript source no more than once for one request while deriving both messages and metadata.
+- Must not retain a full raw `RawSessionEntry[]` copy alongside the final `messages[]` array.
+
+### getAgentSession
+
+```typescript
+export async function getAgentSession(
+  agentId: string,
+  config?: LibraryConfig
+): Promise<Session>;
+```
+
+**Behavioral Contract**:
+- Existing agent lookup, not-found, and ambiguity semantics remain unchanged.
+- Returns additive `preview` metadata for agent transcripts as well.
+- Uses the same one-pass full-detail parser guarantees as `getSession()`.
+
+## Backward Compatibility
+
+- No function signatures change.
+- `SessionSummary.preview` is an additive field and should not break existing consumers that ignore unknown properties.
+- `summary` keeps its current meaning and must not be replaced by derived fallback text.
+- Downstream `vibe-history` code changes are out of scope for this feature, but the new summary field is designed to let that consumer remove full-detail fallback reads in a follow-up change.
+
+## Test Obligations
+
+- Integration tests must prove `listSessions()` returns `preview` for untitled sessions with user-authored text and `null` when no user string message exists.
+- Integration or unit tests must prove `cch list` can display fallback labels from `summary ?? preview ?? '(No summary)'`.
+- Instrumentation tests must prove one `getSession()` or `getAgentSession()` request does not parse the same transcript file more than once.
+- Large-fixture regression tests must prove `listSessions()` stays at or below 512 MiB peak memory while preserving summary rows and agent-link metadata.
+- Parser tests must prove malformed lines remain recoverable and do not block valid later entries.

--- a/specs/010-stream-session-parsing/contracts/library-api.md
+++ b/specs/010-stream-session-parsing/contracts/library-api.md
@@ -57,10 +57,10 @@ export async function listSessions(
 ```
 
 **Behavioral Contract**:
-- Returns one `SessionSummary` per discoverable main session, excluding agent transcripts as top-level rows.
+- Returns one `SessionSummary` per discoverable main session and agent session as top-level rows.
 - Populates `preview` directly from summary parsing so consumers can render fallback labels for untitled sessions without calling `getSession()` per row.
 - Uses one-pass summary scans for compact metadata, preview, and explicit agent-link extraction, and must not retain full raw transcript arrays for every listed session.
-- Preserves existing pagination, workspace filtering, sorting, and linked/unresolved agent ID semantics.
+- Preserves existing pagination, workspace filtering, sorting, and linked/unresolved agent ID semantics on main-session rows; agent-session rows may return empty link arrays.
 - Malformed non-empty JSON lines in one transcript must not abort listing of unrelated sessions; recoverable parse warnings remain internal unless surfaced by an existing caller.
 
 ### getSession
@@ -105,4 +105,5 @@ export async function getAgentSession(
 - Integration or unit tests must prove `cch list` can display fallback labels from `summary ?? preview ?? '(No summary)'`.
 - Instrumentation tests must prove one `getSession()` or `getAgentSession()` request does not parse the same transcript file more than once.
 - Large-fixture regression tests must prove `listSessions()` stays at or below 512 MiB peak memory while preserving summary rows and agent-link metadata.
+- Regression tests must compare baseline-vs-new fallback detail-fetch counts on the same untitled-session fixture and assert at least 90% fewer full detail fetches.
 - Parser tests must prove malformed lines remain recoverable and do not block valid later entries.

--- a/specs/010-stream-session-parsing/data-model.md
+++ b/specs/010-stream-session-parsing/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: Memory-Safe Session Listing and Detail Loading
+
+**Feature**: 010-stream-session-parsing  
+**Date**: 2026-04-03
+
+## Entity: Session Summary
+
+Compact listing record for one main session or one directly requested agent session.
+
+### Fields
+
+- `id: string` - Session UUID for main sessions or `agent-<id>` for agent transcripts.
+- `projectPath: string` - Decoded workspace path for the session.
+- `gitBranch: string | null` - First discovered branch metadata, if present.
+- `summary: string | null` - Explicit Claude summary/title entry, if present.
+- `preview: string | null` - Derived fallback text from the earliest user-authored string message, capped at 200 visible characters after trimming and whitespace normalization.
+- `timestamp: Date` - Earliest user/assistant/progress message timestamp, falling back to file mtime when absent.
+- `lastActivityAt: Date` - Latest user/assistant/progress message timestamp, falling back to file mtime when absent.
+- `messageCount: number` - Count of user, assistant, and progress messages only.
+- `agentIds: string[]` - Discoverable linked child-agent IDs for main sessions.
+- `unresolvedAgentIds: string[]` - Referenced child-agent IDs whose transcripts are not discoverable.
+
+### Validation Rules
+
+- `messageCount` must never include `summary` or `file-history-snapshot` entries.
+- `preview` must be `null` when no user-authored string message exists.
+- `agentIds` and `unresolvedAgentIds` must be unique and sorted, and a given agent ID must not appear in both arrays for the same session.
+- Existing `summary` semantics remain unchanged; fallback text must not overwrite authored titles.
+
+## Entity: Session Detail
+
+Full session object returned by `getSession()` and `getAgentSession()`.
+
+### Fields
+
+- Inherits all `Session Summary` fields, including `preview`.
+- `encodedPath: string` - Encoded project directory name under `projects/`.
+- `version: string` - First discovered Claude Code version string, or empty string when absent.
+- `messages: Message[]` - Full ordered transcript preserving user, assistant, progress, summary, and file-history-snapshot messages.
+
+### Validation Rules
+
+- `messages` must preserve full content fidelity, original order, timestamps, IDs, parent IDs, tool inputs/results, and thinking blocks.
+- Detail parsing must process each transcript source no more than once per request.
+- Agent session details must return empty `agentIds` and `unresolvedAgentIds` arrays.
+
+## Entity: Session Transcript
+
+One JSONL file representing a main or agent session.
+
+### Fields
+
+- `filePath: string` - Absolute path to the transcript file.
+- `storageLayout: 'flat' | 'nested'` - Agent transcript location style.
+- `nestedOwnerSessionId: string | null` - Parent main-session ID inferred from nested agent paths.
+- `modifiedTime: Date` - Filesystem mtime used for sorting and fallback timestamps.
+- `entries: RawSessionEntry stream` - Parsed line stream consumed incrementally rather than retained as an array.
+
+### Validation Rules
+
+- Malformed non-empty JSON lines must produce warnings but must not stop parsing later valid lines.
+- Unreadable transcript files may be skipped during discovery or fail the specific request, but must not corrupt unrelated sessions.
+
+## Entity: Agent Link Analysis
+
+Derived relationship data that links main sessions to discoverable or unresolved agent transcripts.
+
+### Fields
+
+- `explicitAgentIds: string[]` - Agent IDs discovered from explicit task/tool-result evidence inside a main session transcript.
+- `nestedAgentIdsByOwner: Map<mainSessionId, Set<agentId>>` - Agent IDs inferred from nested `subagents/` ownership.
+- `agentSessionsById: Map<agentId, SessionTranscript[]>` - Discoverable agent transcripts by bare agent ID.
+- `explicitAgentOwners: Map<agentId, Set<mainSessionId>>` - Main sessions that explicitly reference each agent ID.
+
+### Validation Rules
+
+- Explicit references remain authoritative when nested-path ownership conflicts with another main session.
+- Project co-location alone is not enough to link an agent transcript.
+- Missing referenced agent IDs must be surfaced through `unresolvedAgentIds` instead of silently dropped.
+
+## Entity: Session Scan Result (Internal)
+
+Internal one-pass parser output used to avoid whole-file raw-entry materialization.
+
+### Fields
+
+- `messages?: Message[]` - Present for full-detail scans.
+- `metadata: SessionMetadata` - Summary/title, version, branch, first/last timestamps, count, session IDs, and preview.
+- `explicitAgentIds?: string[]` - Present for summary/link scans over main sessions.
+- `warnings: ParseWarning[]` - Recoverable parse warnings collected during the scan.
+
+### State Transitions
+
+1. Start with empty scan state.
+2. For each valid parsed transcript entry, update only the selected accumulators (`messages`, `metadata`, `explicitAgentIds`, `preview`).
+3. Drop the raw entry object after the visitor callback returns.
+4. Emit final scan result after the stream ends.

--- a/specs/010-stream-session-parsing/data-model.md
+++ b/specs/010-stream-session-parsing/data-model.md
@@ -17,8 +17,8 @@ Compact listing record for one main session or one directly requested agent sess
 - `timestamp: Date` - Earliest user/assistant/progress message timestamp, falling back to file mtime when absent.
 - `lastActivityAt: Date` - Latest user/assistant/progress message timestamp, falling back to file mtime when absent.
 - `messageCount: number` - Count of user, assistant, and progress messages only.
-- `agentIds: string[]` - Discoverable linked child-agent IDs for main sessions.
-- `unresolvedAgentIds: string[]` - Referenced child-agent IDs whose transcripts are not discoverable.
+- `agentIds: string[]` - Discoverable linked child-agent IDs for main sessions; empty for agent-session rows.
+- `unresolvedAgentIds: string[]` - Referenced child-agent IDs whose transcripts are not discoverable; empty for agent-session rows.
 
 ### Validation Rules
 
@@ -26,6 +26,7 @@ Compact listing record for one main session or one directly requested agent sess
 - `preview` must be `null` when no user-authored string message exists.
 - `agentIds` and `unresolvedAgentIds` must be unique and sorted, and a given agent ID must not appear in both arrays for the same session.
 - Existing `summary` semantics remain unchanged; fallback text must not overwrite authored titles.
+- Top-level summary listing must include both main-session and agent-session rows.
 
 ## Entity: Session Detail
 

--- a/specs/010-stream-session-parsing/plan.md
+++ b/specs/010-stream-session-parsing/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Memory-Safe Session Listing and Detail Loading
+
+**Branch**: `010-stream-session-parsing` | **Date**: 2026-04-03 | **Spec**: [spec.md](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/spec.md)
+**Input**: Feature specification from `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Refactor session parsing so summary listing and detail retrieval scan transcript files once and retain only the derived state they actually need. `listSessions()` gets a lightweight one-pass summary/link parser with bounded first-user preview text, `getSession()` builds messages and metadata in one pass instead of parsing the same transcript twice, and `SessionSummary` gains an additive preview field so `cch list` and downstream consumers can show fallback labels without opening every untitled session.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x with strict mode enabled, running on Node.js 20+  
+**Primary Dependencies**: Commander.js (CLI framework), Node.js built-ins (`fs`, `path`, `readline`)  
+**Storage**: Local Claude Code JSONL session files under `~/.claude/projects/`, including flat `agent-*.jsonl` files and nested `<main-session>/subagents/agent-*.jsonl` files  
+**Testing**: Vitest unit, integration, and performance regression tests for parser/session APIs, CLI list fallback display, large-transcript memory ceilings, and one-pass parse verification  
+**Target Platform**: Node.js 20+ on macOS, Linux, and Windows
+**Project Type**: Single TypeScript project with library and CLI layers  
+**Performance Goals**: `listSessions()` completes a fixture with at least 1,000 sessions and at least 25 very large transcripts at or below 512 MiB peak memory; each `getSession()` request processes its target transcript source no more than once; at least 95% of untitled sessions with a user-authored message expose fallback preview text from summary listing alone  
+**Constraints**: No source transcript mutation; preserve full-fidelity `Session.messages` and metadata in detail retrieval; do not retain a full raw transcript array alongside derived outputs; keep preview support additive and non-breaking; do not modify downstream `vibe-history` consumer code in this branch; avoid new runtime dependencies  
+**Scale/Scope**: One parser/session/library refactor plus CLI list fallback display and regression tests, covering thousands of session files, very large assistant/tool payloads, malformed lines, flat/nested agent links, and untitled-session previews
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Design | ✅ Pass | `cch list` and `cch view` remain the user-facing workflows; summary fallback display is improved with no new command surface. |
+| II. Non-Destructive Operations | ✅ Pass | All planned parser/session changes are read-only over existing transcript files. |
+| III. Cross-Platform Compatibility | ✅ Pass | Design keeps Node.js built-ins and existing platform/path discovery abstractions for macOS, Linux, and Windows. |
+| IV. Library-First Architecture | ✅ Pass | Memory-safe parsing and preview extraction are implemented in `src/lib/`; the CLI consumes the additive summary field. |
+| V. Data Fidelity | ✅ Pass | Full session retrieval still returns complete messages/tool payloads; summary previews are additive and do not replace stored transcript data. |
+
+**Technical Standards Compliance**:
+- TypeScript strict mode and the existing Node.js 20+ single-package setup remain unchanged ✅
+- No new runtime dependencies are required ✅
+- Vitest coverage will be expanded for parser internals, session summaries, one-pass detail retrieval, malformed-line recovery, and large-fixture memory regressions ✅
+- Public API and CLI behavior changes are documented in contracts and remain backward-compatible ✅
+
+### Post-Design Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Design | ✅ Pass | Contracts preserve `cch list`/`cch view` workflows and improve untitled-session labels in list output without new flags. |
+| II. Non-Destructive Operations | ✅ Pass | One-pass scanners only read transcript lines and accumulate derived state; no file writes touch Claude history. |
+| III. Cross-Platform Compatibility | ✅ Pass | Design does not add platform-specific filesystem assumptions beyond existing project/session discovery helpers. |
+| IV. Library-First Architecture | ✅ Pass | `SessionSummary.preview` and parser/session changes are library features first; CLI table rendering only formats those outputs. |
+| V. Data Fidelity | ✅ Pass | Detail parsing remains full-fidelity, and summary parsing extracts bounded previews without mutating the underlying transcript or redefining `summary`. |
+
+No constitution violations require justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-stream-session-parsing/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── cli-interface.md
+│   └── library-api.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── lib/
+│   ├── parser.ts          # Add one-pass scan helpers, summary preview extraction, and combined detail parse
+│   ├── session.ts         # Use summary scan for listing/link analysis and one-pass detail parse for getSession()
+│   ├── types.ts           # Add preview field to SessionSummary / Session
+│   └── index.ts           # Re-export any new public types/helpers if needed
+└── cli/
+    ├── commands/
+    │   └── list.ts        # Keep command behavior stable; consume improved summaries
+    └── formatters/
+        └── table.ts       # Use summary preview as fallback when explicit title is absent
+
+tests/
+├── integration/
+│   ├── list-sessions.test.ts              # Preview fallback and summary-only listing behavior
+│   ├── get-session.test.ts                # One-pass detail retrieval and full-fidelity message output
+│   └── performance/
+│       └── session-lookup.test.ts         # Large-fixture memory ceiling and duplicate-pass regression coverage
+└── unit/
+    ├── parser.test.ts                     # Streaming summary/detail scan helpers and malformed-line recovery
+    └── session.test.ts                    # Listing/detail orchestration and link resolution with preview summaries
+```
+
+**Structure Decision**: Keep the existing single-project `src/lib` + `src/cli` split. Parser/session logic and the additive summary preview field live in the library layer, while CLI table formatting only uses those values for display fallback. Tests stay under the current `tests/unit`, `tests/integration`, and `tests/integration/performance` layout.
+
+## Complexity Tracking
+
+No constitutional or architectural exceptions are required. The feature is a memory-lifetime refactor inside the current library-first architecture with one additive summary field and no new subsystems or dependencies.

--- a/specs/010-stream-session-parsing/plan.md
+++ b/specs/010-stream-session-parsing/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Refactor session parsing so summary listing and detail retrieval scan transcript files once and retain only the derived state they actually need. `listSessions()` gets a lightweight one-pass summary/link parser with bounded first-user preview text, `getSession()` builds messages and metadata in one pass instead of parsing the same transcript twice, and `SessionSummary` gains an additive preview field so `cch list` and downstream consumers can show fallback labels without opening every untitled session.
+Refactor session parsing so summary listing and detail retrieval scan transcript files once and retain only the derived state they actually need. `listSessions()` gets a lightweight one-pass summary/link parser with bounded first-user preview text and top-level rows for both main and agent sessions, `getSession()` builds messages and metadata in one pass instead of parsing the same transcript twice, and `SessionSummary` gains an additive preview field so `cch list` and downstream consumers can show fallback labels without opening every untitled session.
 
 ## Technical Context
 
@@ -17,7 +17,7 @@ Refactor session parsing so summary listing and detail retrieval scan transcript
 **Testing**: Vitest unit, integration, and performance regression tests for parser/session APIs, CLI list fallback display, large-transcript memory ceilings, and one-pass parse verification  
 **Target Platform**: Node.js 20+ on macOS, Linux, and Windows
 **Project Type**: Single TypeScript project with library and CLI layers  
-**Performance Goals**: `listSessions()` completes a fixture with at least 1,000 sessions and at least 25 very large transcripts at or below 512 MiB peak memory; each `getSession()` request processes its target transcript source no more than once; at least 95% of untitled sessions with a user-authored message expose fallback preview text from summary listing alone  
+**Performance Goals**: `listSessions()` returns top-level main-session and agent-session rows, completes a fixture with at least 1,000 sessions and at least 25 very large transcripts at or below 512 MiB peak memory, each `getSession()` request processes its target transcript source no more than once, at least 95% of untitled sessions with a user-authored message expose fallback preview text from summary listing alone, and baseline-vs-new tests show at least 90% fewer fallback detail-fetches on the same fixture
 **Constraints**: No source transcript mutation; preserve full-fidelity `Session.messages` and metadata in detail retrieval; do not retain a full raw transcript array alongside derived outputs; keep preview support additive and non-breaking; do not modify downstream `vibe-history` consumer code in this branch; avoid new runtime dependencies  
 **Scale/Scope**: One parser/session/library refactor plus CLI list fallback display and regression tests, covering thousands of session files, very large assistant/tool payloads, malformed lines, flat/nested agent links, and untitled-session previews
 
@@ -35,6 +35,9 @@ Refactor session parsing so summary listing and detail retrieval scan transcript
 | IV. Library-First Architecture | ✅ Pass | Memory-safe parsing and preview extraction are implemented in `src/lib/`; the CLI consumes the additive summary field. |
 | V. Data Fidelity | ✅ Pass | Full session retrieval still returns complete messages/tool payloads; summary previews are additive and do not replace stored transcript data. |
 
+**Governance Exception**:
+- The feature branch remains `010-stream-session-parsing` as an explicit one-off exception to the constitution's `<type>/<short-description>` branch naming convention so the generated Spec Kit branch and `specs/010-stream-session-parsing/` directory stay aligned.
+
 **Technical Standards Compliance**:
 - TypeScript strict mode and the existing Node.js 20+ single-package setup remain unchanged ✅
 - No new runtime dependencies are required ✅
@@ -51,7 +54,7 @@ Refactor session parsing so summary listing and detail retrieval scan transcript
 | IV. Library-First Architecture | ✅ Pass | `SessionSummary.preview` and parser/session changes are library features first; CLI table rendering only formats those outputs. |
 | V. Data Fidelity | ✅ Pass | Detail parsing remains full-fidelity, and summary parsing extracts bounded previews without mutating the underlying transcript or redefining `summary`. |
 
-No constitution violations require justification.
+The only constitution-related exception is the branch naming convention deviation documented above and in Complexity Tracking.
 
 ## Project Structure
 
@@ -92,11 +95,14 @@ tests/
 │       └── session-lookup.test.ts         # Large-fixture memory ceiling and duplicate-pass regression coverage
 └── unit/
     ├── parser.test.ts                     # Streaming summary/detail scan helpers and malformed-line recovery
-    └── session.test.ts                    # Listing/detail orchestration and link resolution with preview summaries
+    ├── session.test.ts                    # Listing/detail orchestration and link resolution with preview summaries
+    └── cli/
+        └── formatters/
+            └── table.test.ts              # Summary/preview/(No summary) fallback rendering
 ```
 
 **Structure Decision**: Keep the existing single-project `src/lib` + `src/cli` split. Parser/session logic and the additive summary preview field live in the library layer, while CLI table formatting only uses those values for display fallback. Tests stay under the current `tests/unit`, `tests/integration`, and `tests/integration/performance` layout.
 
 ## Complexity Tracking
 
-No constitutional or architectural exceptions are required. The feature is a memory-lifetime refactor inside the current library-first architecture with one additive summary field and no new subsystems or dependencies.
+No architectural exceptions are required. The only documented governance exception is the generated branch name `010-stream-session-parsing`, which intentionally keeps the Spec Kit numeric branch format instead of `<type>/<short-description>` for this one branch.

--- a/specs/010-stream-session-parsing/quickstart.md
+++ b/specs/010-stream-session-parsing/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart: Memory-Safe Session Listing and Detail Loading
+
+**Feature**: 010-stream-session-parsing  
+**Date**: 2026-04-03
+
+## Overview
+
+This guide maps the OOM fix onto the current codebase so implementation can proceed without re-deriving parser/session responsibilities.
+
+## What We’re Building
+
+- `listSessions()` uses a lightweight one-pass summary/link scan and exposes `SessionSummary.preview` for untitled-session fallback labels.
+- `getSession()` and `getAgentSession()` derive messages and metadata in one transcript pass and no longer parse the same file twice.
+- Parser internals stop accumulating a whole-file raw-entry array when callers only need derived summary or message state.
+- `cch list` displays `summary ?? preview ?? '(No summary)'` with no new flags.
+- Large-fixture regression tests enforce the 512 MiB session-listing ceiling and protect the no-duplicate-parse invariant.
+
+## Key Files To Modify
+
+| File | Purpose | Planned Change |
+|------|---------|----------------|
+| `src/lib/parser.ts` | JSONL parsing, message transforms, metadata/link extraction | Add reusable one-pass scan helpers, bounded preview extraction, and combined detail parse output |
+| `src/lib/session.ts` | Session listing, link analysis, and session retrieval orchestration | Use summary scans for listing/link context and one-pass full-detail parsing for `getSession()` / `getAgentSession()` |
+| `src/lib/types.ts` | Public summary/detail types | Add additive `preview: string \| null` to `SessionSummary` |
+| `src/cli/formatters/table.ts` | Human-readable `cch list` rendering | Fall back from `summary` to `preview` before `(No summary)` |
+| `tests/unit/parser.test.ts` | Parser unit coverage | Validate preview extraction, summary scan metadata, one-pass detail scan behavior, and malformed-line recovery |
+| `tests/unit/session.test.ts` | Session orchestration coverage | Validate summary/list behavior, preview propagation, and one-pass detail parser usage |
+| `tests/integration/list-sessions.test.ts` | End-to-end listing behavior | Verify fallback previews appear in summaries and malformed large sessions remain listable |
+| `tests/integration/get-session.test.ts` | End-to-end detail retrieval | Verify full-fidelity messages and no duplicate transcript parsing per request |
+| `tests/integration/performance/session-lookup.test.ts` | Performance regressions | Verify large-fixture listing stays at or below 512 MiB peak memory |
+
+## Suggested Implementation Order
+
+### Step 1: Introduce One-Pass Parser Primitives
+
+- Add a parser helper that streams JSONL lines and invokes a visitor/accumulator for each valid `RawSessionEntry`.
+- Build summary metadata, first-user preview, and explicit agent-link extraction on top of that helper.
+- Build a full-detail parser that transforms messages and updates metadata in the same scan.
+- Keep malformed non-empty lines recoverable by collecting parse warnings and continuing.
+
+### Step 2: Rewire Session Listing and Detail Retrieval
+
+- Replace `analyzeMainSessions()` and summary construction so listing uses one-pass summary/link scans rather than `parseJsonlFile()` plus whole-entry post-processing.
+- Replace `loadSessionRecord()` so one `getSession()` request reads its target transcript once and returns messages plus metadata from the same scan.
+- Preserve current sorting, pagination, workspace filtering, agent-link resolution, and not-found/ambiguity semantics.
+
+### Step 3: Expose Summary Preview Fallbacks
+
+- Add `preview` to `SessionSummary` and inherit it in `Session`.
+- Populate `preview` from the earliest user-authored string message, trim and normalize whitespace, and cap to 200 visible characters.
+- Update `formatSessionTable()` to render explicit `summary`, then `preview`, then `(No summary)`.
+- Keep `summary` semantics unchanged and treat `preview` as an additive fallback field only.
+
+### Step 4: Lock Behavior With Tests
+
+- Add parser/session tests that prove malformed records are skipped, preview extraction is bounded, and one-pass helpers produce the expected metadata and messages.
+- Add instrumentation coverage proving one `getSession()` call does not trigger duplicate target-file parses.
+- Add large synthetic fixture coverage proving `listSessions()` completes at or below 512 MiB peak memory and still returns all expected summary rows and agent links.
+- Run the full existing validation suite to protect compatibility.
+
+## Verification Commands
+
+```bash
+npm run typecheck
+npm test
+npm run lint
+node dist/cli/index.js list
+node dist/cli/index.js list --json
+node dist/cli/index.js view 0 --json
+```
+
+## Expected Outcomes
+
+- `listSessions()` returns compact summaries with fallback `preview` text and no longer requires whole-session raw-entry arrays per listed session.
+- `getSession()` and `getAgentSession()` return full-fidelity messages and metadata while parsing each target transcript once.
+- `cch list` shows useful labels for untitled sessions without opening the full transcript.
+- Large malformed or oversized transcripts remain listable and inspectable without OOM under the agreed regression fixture.

--- a/specs/010-stream-session-parsing/quickstart.md
+++ b/specs/010-stream-session-parsing/quickstart.md
@@ -9,10 +9,10 @@ This guide maps the OOM fix onto the current codebase so implementation can proc
 
 ## What We’re Building
 
-- `listSessions()` uses a lightweight one-pass summary/link scan and exposes `SessionSummary.preview` for untitled-session fallback labels.
+- `listSessions()` uses a lightweight one-pass summary/link scan, returns top-level rows for both main and agent sessions, and exposes `SessionSummary.preview` for untitled-session fallback labels.
 - `getSession()` and `getAgentSession()` derive messages and metadata in one transcript pass and no longer parse the same file twice.
 - Parser internals stop accumulating a whole-file raw-entry array when callers only need derived summary or message state.
-- `cch list` displays `summary ?? preview ?? '(No summary)'` with no new flags.
+- `cch list` displays `summary ?? preview ?? '(No summary)'`, includes agent sessions as top-level rows, and uses no new flags.
 - Large-fixture regression tests enforce the 512 MiB session-listing ceiling and protect the no-duplicate-parse invariant.
 
 ## Key Files To Modify
@@ -25,9 +25,10 @@ This guide maps the OOM fix onto the current codebase so implementation can proc
 | `src/cli/formatters/table.ts` | Human-readable `cch list` rendering | Fall back from `summary` to `preview` before `(No summary)` |
 | `tests/unit/parser.test.ts` | Parser unit coverage | Validate preview extraction, summary scan metadata, one-pass detail scan behavior, and malformed-line recovery |
 | `tests/unit/session.test.ts` | Session orchestration coverage | Validate summary/list behavior, preview propagation, and one-pass detail parser usage |
-| `tests/integration/list-sessions.test.ts` | End-to-end listing behavior | Verify fallback previews appear in summaries and malformed large sessions remain listable |
+| `tests/integration/list-sessions.test.ts` | End-to-end listing behavior | Verify fallback previews appear in summaries, agent sessions are top-level rows, and malformed large sessions remain listable |
 | `tests/integration/get-session.test.ts` | End-to-end detail retrieval | Verify full-fidelity messages and no duplicate transcript parsing per request |
 | `tests/integration/performance/session-lookup.test.ts` | Performance regressions | Verify large-fixture listing stays at or below 512 MiB peak memory |
+| `tests/unit/cli/formatters/table.test.ts` | CLI table fallback rendering | Verify `summary`, then 200-character `preview`, then `(No summary)` fallback behavior |
 
 ## Suggested Implementation Order
 
@@ -40,7 +41,7 @@ This guide maps the OOM fix onto the current codebase so implementation can proc
 
 ### Step 2: Rewire Session Listing and Detail Retrieval
 
-- Replace `analyzeMainSessions()` and summary construction so listing uses one-pass summary/link scans rather than `parseJsonlFile()` plus whole-entry post-processing.
+- Replace `analyzeMainSessions()` and summary construction so listing uses one-pass summary/link scans rather than `parseJsonlFile()` plus whole-entry post-processing, and return both main and agent sessions as top-level rows.
 - Replace `loadSessionRecord()` so one `getSession()` request reads its target transcript once and returns messages plus metadata from the same scan.
 - Preserve current sorting, pagination, workspace filtering, agent-link resolution, and not-found/ambiguity semantics.
 
@@ -55,7 +56,8 @@ This guide maps the OOM fix onto the current codebase so implementation can proc
 
 - Add parser/session tests that prove malformed records are skipped, preview extraction is bounded, and one-pass helpers produce the expected metadata and messages.
 - Add instrumentation coverage proving one `getSession()` call does not trigger duplicate target-file parses.
-- Add large synthetic fixture coverage proving `listSessions()` completes at or below 512 MiB peak memory and still returns all expected summary rows and agent links.
+- Add large synthetic fixture coverage proving `listSessions()` completes at or below 512 MiB peak memory and still returns all expected main/agent summary rows and agent links.
+- Add baseline-vs-new fallback-fetch regression coverage proving at least 90% fewer full detail reads are needed for untitled-session preview rendering.
 - Run the full existing validation suite to protect compatibility.
 
 ## Verification Commands

--- a/specs/010-stream-session-parsing/research.md
+++ b/specs/010-stream-session-parsing/research.md
@@ -1,0 +1,64 @@
+# Phase 0 Research: Memory-Safe Session Listing and Detail Loading
+
+**Feature**: 010-stream-session-parsing  
+**Date**: 2026-04-03
+
+## Decision 1: Replace whole-file raw-entry accumulation with a one-pass session scanner
+
+**Decision**: Introduce a reusable parser helper that reads one JSONL line at a time, parses it, and immediately forwards each valid `RawSessionEntry` to caller-provided accumulation logic instead of pushing every entry into a shared `entries[]` array. Build summary and full-detail parsers on top of that scanner so callers keep only their own aggregate state (`messages[]`, summary metadata, preview text, agent IDs, warnings).
+
+**Rationale**: The current parser streams only at the I/O boundary but still retains the full raw object graph in memory. A one-pass scanner keeps line-by-line parsing and error recovery while making object lifetime explicit, which directly addresses the OOM path described in the spec.
+
+**Alternatives considered**:
+- Keep `parseJsonlFile()` returning `RawSessionEntry[]` and rely on garbage collection after transformation. Rejected because peak memory still includes all raw entries plus derived messages.
+- Read each file into memory with `fs.readFile()` and parse a full buffer. Rejected because it worsens memory pressure on large transcripts.
+
+## Decision 2: Parse `getSession()` detail and metadata in one pass
+
+**Decision**: Replace the current parallel `parseSessionFile()` + `parseSessionMetadata()` workflow with a single detail parser that transforms messages and updates session metadata during the same transcript scan, returning one combined result per file.
+
+**Rationale**: Parsing the same file twice concurrently can create two raw-entry aggregates and duplicate expensive JSON object graphs. A single-pass detail parser removes redundant work, lowers peak heap usage, and keeps full-fidelity `Session.messages` output.
+
+**Alternatives considered**:
+- Run metadata parse and full message parse sequentially instead of in parallel. Rejected because it still doubles file parsing and CPU work for every detail request.
+- Keep the parallel approach but cache one parse result globally. Rejected because cache lifetime and invalidation add complexity and can retain large sessions longer than needed.
+
+## Decision 3: Add a lightweight summary/link parser for `listSessions()`
+
+**Decision**: Add a one-pass summary parser for main-session listing that extracts explicit titles, first/last activity timestamps, message counts, branch/version metadata, linked agent IDs, and a bounded fallback preview from the earliest user-authored string message. Use that parser in `analyzeMainSessions()` and summary construction instead of `parseJsonlFile()` + full-entry post-processing.
+
+**Rationale**: `listSessions()` only needs compact summary fields and agent-link evidence for each row. Computing those fields incrementally avoids retaining complete transcripts for each listed session and eliminates the downstream need to open every untitled session just to derive fallback labels.
+
+**Alternatives considered**:
+- Continue deriving fallback preview text by calling `getSession()` from consumers. Rejected because that forces full-detail reads for many untitled sessions and reproduces OOM risk at the integration layer.
+- Overwrite `summary` with fallback preview text when no explicit title exists. Rejected because it loses the distinction between authored titles and derived preview text.
+
+## Decision 4: Expose fallback previews as an additive `SessionSummary.preview` field
+
+**Decision**: Add `preview: string | null` to `SessionSummary`, inherited by `Session`, where `summary` remains the explicit title and `preview` is a bounded first-user fallback. Render `summary ?? preview ?? '(No summary)'` in `cch list` human-readable output and include `preview` in JSON list output.
+
+**Rationale**: This preserves backward compatibility for existing consumers that rely on `summary`, gives downstream integrations the data needed to avoid full-detail fallback reads, and keeps title/preview semantics separate and explicit.
+
+**Alternatives considered**:
+- Rename or repurpose `summary` to hold either a title or preview. Rejected because it is behaviorally ambiguous and risks breaking consumers that distinguish authored summaries from derived text.
+- Add preview data only to CLI output. Rejected because library consumers would still need `getSession()` for fallback labels.
+
+## Decision 5: Bound preview text length during summary scans
+
+**Decision**: Capture at most the first 200 visible characters of the earliest user-authored string message after trimming and whitespace normalization; return `null` when no user string message exists.
+
+**Rationale**: A bounded preview prevents a single huge prompt from inflating every `SessionSummary`, while 200 characters is enough for fallback labels and aligns with existing display-preview scale elsewhere in the codebase.
+
+**Alternatives considered**:
+- Store the full first user message in `SessionSummary.preview`. Rejected because very large prompts would reintroduce summary-listing memory growth.
+- Cap preview at the CLI table column width only. Rejected because JSON consumers need a more useful fallback string than a 30-column display snippet.
+
+## Decision 6: Verify memory and one-pass behavior with dedicated regression tests
+
+**Decision**: Add large synthetic JSONL fixtures and targeted instrumentation tests that prove `listSessions()` stays at or below 512 MiB peak memory on a high-volume fixture, `getSession()` scans its target transcript no more than once per request, malformed lines remain recoverable, and summary previews are available without per-session detail fetches.
+
+**Rationale**: The bug is a performance and memory-lifetime regression class, so correctness tests alone are insufficient. Regression coverage must enforce the 512 MiB ceiling and protect the no-duplicate-parse invariant.
+
+**Alternatives considered**:
+- Rely on unit tests for parser output only. Rejected because they do not catch heap growth from large fixture shape or duplicate session scans in orchestration code.
+- Measure memory informally during manual testing only. Rejected because the OOM risk can reappear silently without automated performance gates.

--- a/specs/010-stream-session-parsing/spec.md
+++ b/specs/010-stream-session-parsing/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Memory-Safe Session Listing and Detail Loading
+
+**Feature Branch**: `010-stream-session-parsing`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+**Input**: User description: "Avoid full-session materialization during summary listing and duplicate full-file parses during getSession(); large Claude transcripts can cause OOM when listing or syncing sessions, especially when downstream consumers fetch every untitled session just to derive fallback preview text."
+
+## Clarifications
+
+### Session 2026-04-03
+
+- Q: What peak-memory ceiling should large-fixture session-listing regression tests enforce? → A: 512 MiB peak during large-fixture listSessions().
+- Q: Should this feature include downstream vibe-history code changes, or only claude-code-history parser/API changes? → A: CCH library changes only; no vibe-history code changes in this feature.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List large session histories without memory failures (Priority: P1)
+
+A developer or downstream product user can list session history for a project that contains many large conversations, including transcripts with long tool outputs, and receive stable summaries without the command terminating from memory exhaustion.
+
+**Why this priority**: Session listing and sync are the first entry point into the history experience; if they fail on large projects, users cannot discover or navigate any conversations.
+
+**Independent Test**: Run session listing against a fixture with many large conversations and verify that summaries are returned, peak memory stays at or below 512 MiB, and no full conversation content is required for sessions that are only being summarized.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project containing many large session transcripts, **When** the user lists sessions, **Then** the user receives one summary per discoverable session without a memory-exhaustion failure.
+2. **Given** a session that has no explicit title but does contain user-authored messages, **When** the user lists sessions, **Then** the summary includes a preview derived from the earliest user-authored message so the session can be recognized without opening the full transcript.
+3. **Given** a session with linked agent activity, **When** the user lists sessions, **Then** the summary includes the agent-link information needed to represent that relationship.
+
+---
+
+### User Story 2 - Open a large session without duplicate transcript processing (Priority: P2)
+
+A developer can open a single large session and inspect the full conversation plus its metadata without the system redundantly reprocessing the same transcript in a way that spikes peak memory usage.
+
+**Why this priority**: Users need full message content for investigation and review, but a single detail request should not become unreliable or excessively memory-intensive.
+
+**Independent Test**: Open one synthetic session with very large assistant and tool output payloads and verify that the full transcript and metadata are returned while the session source is processed at most once for that request.
+
+**Acceptance Scenarios**:
+
+1. **Given** a large session transcript with many messages and metadata fields, **When** the user opens that session, **Then** the user receives the complete normalized conversation and session metadata from one request without a memory-exhaustion failure.
+2. **Given** instrumentation that records transcript processing passes for one session-detail request, **When** the user opens that session, **Then** the same transcript is not processed more than once for that request.
+
+---
+
+### User Story 3 - Render previews in downstream listings without fetching every full session (Priority: P3)
+
+A downstream consumer that displays Claude history can build useful fallback titles/previews directly from listing results instead of opening every untitled session, reducing memory pressure and unnecessary detail reads. This feature must provide that summary data from `claude-code-history`, but downstream application code changes are out of scope for this branch.
+
+**Why this priority**: This removes an integration-layer trigger for OOM and makes listing-based experiences faster and safer at scale.
+
+**Independent Test**: For a mixed set of titled and untitled sessions, request only summaries and verify that a downstream listing view can render previews for untitled sessions without issuing per-session detail reads.
+
+**Acceptance Scenarios**:
+
+1. **Given** a collection of untitled sessions where each session has at least one user message, **When** a consumer renders a listing from summary data only, **Then** the consumer can display fallback preview text for each such session without opening the full session details.
+2. **Given** a session with no usable title and no extractable user preview text, **When** a consumer renders a listing from summary data only, **Then** the consumer still receives a safe fallback label and the rest of the listing remains usable.
+
+---
+
+### Edge Cases
+
+- A transcript contains malformed or partially written records mixed with valid records.
+- A transcript contains extremely large tool output or assistant message payloads.
+- A session has no title, no user-authored messages, or only system/tool records.
+- A linked agent transcript is missing, unreadable, or references a session that is no longer present.
+- Multiple large sessions are listed in one request while another consumer simultaneously opens individual session details.
+- Session timestamps, branch metadata, or agent-link metadata are missing or inconsistent across records.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Session listing MUST return summary rows for all discoverable sessions without requiring the full message history of each listed session to be retained in memory at the same time.
+- **FR-002**: Session summaries MUST include, when available, the session title, a fallback preview derived from the earliest user-authored message, first and last activity timestamps, message count, branch name, and linked agent-session relationships.
+- **FR-003**: Session-detail retrieval MUST return the full normalized conversation and summary metadata for the requested session while ensuring that each underlying transcript source is processed no more than once per request.
+- **FR-004**: Summary-only workflows MUST be able to compute titles, preview text, timestamps, message counts, branch metadata, and agent links incrementally without retaining a full raw transcript representation for every listed session.
+- **FR-005**: When a transcript record is malformed, incomplete, or missing nonessential metadata, the system MUST continue processing the rest of the session or listing, expose a safe fallback value where possible, and avoid failing the entire request unless the session source itself is unreadable.
+- **FR-006**: Existing consumers of session summaries and session details MUST continue to receive all previously exposed user-visible session information, with preview text added to summaries as a non-breaking extension.
+- **FR-007**: Session listing MUST provide enough preview information for downstream consumers to generate fallback labels for untitled sessions without fetching each full session detail individually.
+- **FR-008**: Regression coverage MUST include large synthetic sessions with oversized assistant/tool-result content and verify both successful completion with session-listing peak memory at or below 512 MiB and the absence of duplicate processing passes for one session-detail request.
+- **FR-009**: This feature MUST deliver the parser, summary, and detail-loading changes in `claude-code-history` only; modifying downstream `vibe-history` consumer code is explicitly out of scope.
+
+### Key Entities
+
+- **Session Summary**: A compact representation of one conversation for listing views, including title or fallback preview, activity timestamps, message count, branch metadata, and agent-link references.
+- **Session Detail**: The full ordered conversation for one session plus the metadata needed to display and relate that session in history views.
+- **Session Transcript**: The source record sequence for one conversation, which may contain user messages, assistant messages, tool outputs, metadata, and malformed or partial records.
+- **Agent Link**: A relationship between a main session and a child agent session, including the identifiers and display metadata needed for navigation.
+
+## Assumptions
+
+- Preview text for untitled sessions should use the earliest user-authored message after trimming whitespace and applying a reasonable display-length limit; if no such message exists, the existing generic fallback label remains acceptable.
+- The feature should preserve current session discovery and detail semantics while reducing peak memory usage and redundant transcript processing.
+- Memory validation can use large synthetic transcript fixtures that reflect the size and shape of real conversations with very large tool outputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Listing a fixture with at least 1,000 sessions, including at least 25 very large transcripts, completes successfully with no memory-exhaustion failure and with peak memory at or below 512 MiB.
+- **SC-002**: Opening one very large session returns the complete conversation and metadata successfully, and validation shows that the session source was processed no more than once for that request.
+- **SC-003**: For at least 95% of untitled sessions that contain a user-authored message, listing results alone provide enough preview text for a consumer to render a meaningful fallback label without a detail fetch.
+- **SC-004**: Compared with the current behavior on the same large-session fixture, the number of full session-detail fetches needed solely for fallback previews in downstream listings is reduced by at least 90%.
+- **SC-005**: In repeated runs over large synthetic fixtures, session listing and single-session detail retrieval both complete with zero unhandled failures caused by malformed individual transcript records.

--- a/specs/010-stream-session-parsing/spec.md
+++ b/specs/010-stream-session-parsing/spec.md
@@ -11,6 +11,11 @@
 
 - Q: What peak-memory ceiling should large-fixture session-listing regression tests enforce? → A: 512 MiB peak during large-fixture listSessions().
 - Q: Should this feature include downstream vibe-history code changes, or only claude-code-history parser/API changes? → A: CCH library changes only; no vibe-history code changes in this feature.
+- Q: Should the current feature branch be renamed to match the constitution's `<type>/<short-description>` convention? → A: Keep `010-stream-session-parsing` and document it as an explicit branch-name exception for this Spec Kit branch.
+- Q: Should `listSessions()`/`cch list` include agent sessions as top-level rows? → A: Yes. Return both main-session and agent-session summaries as top-level rows, while main sessions still expose linked agent IDs.
+- Q: What exact preview length cap and fallback label should summaries use? → A: Cap `preview` at 200 characters and use `(No summary)` when neither `summary` nor `preview` is available.
+- Q: How should the 90% fallback-detail-fetch reduction target be validated? → A: Add an explicit baseline-vs-new regression test that compares fallback detail-fetch counts on the same fixture and asserts at least 90% reduction.
+- Q: How should the plan/tasks test-path mismatch be resolved? → A: Add `tests/unit/cli/formatters/table.test.ts` to the implementation plan's test tree.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -24,7 +29,7 @@ A developer or downstream product user can list session history for a project th
 
 **Acceptance Scenarios**:
 
-1. **Given** a project containing many large session transcripts, **When** the user lists sessions, **Then** the user receives one summary per discoverable session without a memory-exhaustion failure.
+1. **Given** a project containing many large main-session and agent-session transcripts, **When** the user lists sessions, **Then** the user receives one summary per discoverable main or agent session without a memory-exhaustion failure.
 2. **Given** a session that has no explicit title but does contain user-authored messages, **When** the user lists sessions, **Then** the summary includes a preview derived from the earliest user-authored message so the session can be recognized without opening the full transcript.
 3. **Given** a session with linked agent activity, **When** the user lists sessions, **Then** the summary includes the agent-link information needed to represent that relationship.
 
@@ -55,8 +60,8 @@ A downstream consumer that displays Claude history can build useful fallback tit
 
 **Acceptance Scenarios**:
 
-1. **Given** a collection of untitled sessions where each session has at least one user message, **When** a consumer renders a listing from summary data only, **Then** the consumer can display fallback preview text for each such session without opening the full session details.
-2. **Given** a session with no usable title and no extractable user preview text, **When** a consumer renders a listing from summary data only, **Then** the consumer still receives a safe fallback label and the rest of the listing remains usable.
+1. **Given** a collection of untitled sessions where each session has at least one user message, **When** a consumer renders a listing from summary data only, **Then** the consumer can display fallback preview text of at most 200 characters for each such session without opening the full session details.
+2. **Given** a session with no usable title and no extractable user preview text, **When** a consumer renders a listing from summary data only, **Then** the consumer still receives `(No summary)` as the fallback label and the rest of the listing remains usable.
 
 ---
 
@@ -73,26 +78,26 @@ A downstream consumer that displays Claude history can build useful fallback tit
 
 ### Functional Requirements
 
-- **FR-001**: Session listing MUST return summary rows for all discoverable sessions without requiring the full message history of each listed session to be retained in memory at the same time.
-- **FR-002**: Session summaries MUST include, when available, the session title, a fallback preview derived from the earliest user-authored message, first and last activity timestamps, message count, branch name, and linked agent-session relationships.
+- **FR-001**: Session listing MUST return top-level summary rows for all discoverable main sessions and agent sessions without requiring the full message history of each listed session to be retained in memory at the same time.
+- **FR-002**: Session summaries MUST include, when available, the session title, a fallback preview derived from the earliest user-authored message and capped at 200 characters, first and last activity timestamps, message count, branch name, and linked agent-session relationships for main-session rows.
 - **FR-003**: Session-detail retrieval MUST return the full normalized conversation and summary metadata for the requested session while ensuring that each underlying transcript source is processed no more than once per request.
 - **FR-004**: Summary-only workflows MUST be able to compute titles, preview text, timestamps, message counts, branch metadata, and agent links incrementally without retaining a full raw transcript representation for every listed session.
-- **FR-005**: When a transcript record is malformed, incomplete, or missing nonessential metadata, the system MUST continue processing the rest of the session or listing, expose a safe fallback value where possible, and avoid failing the entire request unless the session source itself is unreadable.
+- **FR-005**: When a transcript record is malformed, incomplete, or missing nonessential metadata, the system MUST continue processing the rest of the session or listing, expose `(No summary)` when neither a title nor preview is available, and avoid failing the entire request unless the session source itself is unreadable.
 - **FR-006**: Existing consumers of session summaries and session details MUST continue to receive all previously exposed user-visible session information, with preview text added to summaries as a non-breaking extension.
 - **FR-007**: Session listing MUST provide enough preview information for downstream consumers to generate fallback labels for untitled sessions without fetching each full session detail individually.
-- **FR-008**: Regression coverage MUST include large synthetic sessions with oversized assistant/tool-result content and verify both successful completion with session-listing peak memory at or below 512 MiB and the absence of duplicate processing passes for one session-detail request.
+- **FR-008**: Regression coverage MUST include large synthetic sessions with oversized assistant/tool-result content and verify successful completion with session-listing peak memory at or below 512 MiB, the absence of duplicate processing passes for one session-detail request, and at least 90% fewer fallback detail-fetches than the baseline untitled-session listing flow on the same fixture.
 - **FR-009**: This feature MUST deliver the parser, summary, and detail-loading changes in `claude-code-history` only; modifying downstream `vibe-history` consumer code is explicitly out of scope.
 
 ### Key Entities
 
-- **Session Summary**: A compact representation of one conversation for listing views, including title or fallback preview, activity timestamps, message count, branch metadata, and agent-link references.
+- **Session Summary**: A compact representation of one main or agent conversation for listing views, including title or fallback preview, activity timestamps, message count, branch metadata, and agent-link references for main-session rows.
 - **Session Detail**: The full ordered conversation for one session plus the metadata needed to display and relate that session in history views.
 - **Session Transcript**: The source record sequence for one conversation, which may contain user messages, assistant messages, tool outputs, metadata, and malformed or partial records.
 - **Agent Link**: A relationship between a main session and a child agent session, including the identifiers and display metadata needed for navigation.
 
 ## Assumptions
 
-- Preview text for untitled sessions should use the earliest user-authored message after trimming whitespace and applying a reasonable display-length limit; if no such message exists, the existing generic fallback label remains acceptable.
+- Preview text for untitled sessions should use the earliest user-authored message after trimming whitespace, applying a 200-character cap, and falling back to `(No summary)` if no title or preview exists.
 - The feature should preserve current session discovery and detail semantics while reducing peak memory usage and redundant transcript processing.
 - Memory validation can use large synthetic transcript fixtures that reflect the size and shape of real conversations with very large tool outputs.
 
@@ -103,5 +108,5 @@ A downstream consumer that displays Claude history can build useful fallback tit
 - **SC-001**: Listing a fixture with at least 1,000 sessions, including at least 25 very large transcripts, completes successfully with no memory-exhaustion failure and with peak memory at or below 512 MiB.
 - **SC-002**: Opening one very large session returns the complete conversation and metadata successfully, and validation shows that the session source was processed no more than once for that request.
 - **SC-003**: For at least 95% of untitled sessions that contain a user-authored message, listing results alone provide enough preview text for a consumer to render a meaningful fallback label without a detail fetch.
-- **SC-004**: Compared with the current behavior on the same large-session fixture, the number of full session-detail fetches needed solely for fallback previews in downstream listings is reduced by at least 90%.
+- **SC-004**: Compared with the current behavior on the same large-session fixture, an automated baseline-vs-new regression test shows that the number of full session-detail fetches needed solely for fallback previews in downstream listings is reduced by at least 90%.
 - **SC-005**: In repeated runs over large synthetic fixtures, session listing and single-session detail retrieval both complete with zero unhandled failures caused by malformed individual transcript records.

--- a/specs/010-stream-session-parsing/tasks.md
+++ b/specs/010-stream-session-parsing/tasks.md
@@ -1,0 +1,230 @@
+# Tasks: Memory-Safe Session Listing and Detail Loading
+
+**Input**: Design documents from `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/`
+**Prerequisites**: [plan.md](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/plan.md), [spec.md](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/spec.md), [research.md](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/research.md), [data-model.md](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/data-model.md), [contracts/](/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts)
+
+**Tests**: Regression tests are required by `FR-008`, `SC-001`, `SC-002`, and the library/CLI contracts. Add tests first in each story phase and verify they fail before implementing the story code.
+
+**Organization**: Tasks are grouped by user story in spec priority order (`US1`, `US2`, `US3`) so the memory-safe listing MVP can land first and later stories can be validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Task can run in parallel with sibling tasks because it touches a different file and has no dependency on unfinished tasks
+- **[Story]**: User-story label for story phases only (`[US1]`, `[US2]`, `[US3]`)
+- Every task below includes one or more absolute file paths
+
+## Path Conventions
+
+- Repository root: `/Users/borui/Devs/vibe-coding-history/claude-code-history`
+- Library code: `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/`
+- CLI code: `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/`
+- Tests: `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare large-transcript fixture and parser-scan instrumentation helpers used by all story tests.
+
+- [ ] T001 [P] Create large synthetic JSONL fixture builders for long user/tool payloads and untitled sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/large-session-fixtures.ts`
+- [ ] T002 [P] Create parser scan-count and heap-sampling test helpers for one-pass and 512 MiB regression checks in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/parser-performance.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared parser/type primitives that all user stories depend on.
+
+**CRITICAL**: Do not start story implementation until this phase is complete.
+
+- [ ] T003 [P] Add failing parser unit tests for one-pass line scanning, bounded preview normalization, and malformed-line recovery in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/parser.test.ts`
+- [ ] T004 [P] Add failing session orchestration unit tests for summary preview propagation and one-pass detail parser usage in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
+- [ ] T005 [P] Add additive `preview: string | null` to `SessionSummary` and inherited `Session` docs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/types.ts`
+- [ ] T006 Implement a reusable one-pass JSONL scan helper that forwards each valid `RawSessionEntry` to an accumulator callback and drops the raw entry immediately in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [ ] T007 Extend `SessionMetadata` and parser accumulator helpers with first-user `preview` extraction, first/last timestamps, message counts, and version/branch/session IDs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+
+**Checkpoint**: Foundation ready when parser and type primitives compile and the new foundational tests fail only on unimplemented story behavior.
+
+---
+
+## Phase 3: User Story 1 - List large session histories without memory failures (Priority: P1) MVP
+
+**Goal**: `listSessions()` returns compact summaries, preview fallback text, timestamps, message counts, and agent links without OOM or whole-session raw-entry retention.
+
+**Independent Test**: Run `listSessions()` on a fixture with many large transcripts and verify one summary per main session, preview values for untitled sessions, preserved agent links, and peak memory at or below 512 MiB.
+
+### Tests for User Story 1
+
+- [ ] T008 [P] [US1] Add failing `listSessions()` integration tests for untitled-session `preview`, agent link metadata, malformed-line recovery, and title/preview precedence in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts`
+- [ ] T009 [P] [US1] Add a failing 1,000-session performance regression test that asserts `listSessions()` peak memory stays at or below 512 MiB while preserving summary rows in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/performance/session-lookup.test.ts`
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Implement one-pass summary/link parsing that derives `summary`, bounded `preview`, timestamps, message counts, branch/version metadata, and explicit agent IDs without `RawSessionEntry[]` accumulation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [ ] T011 [US1] Rewire `analyzeMainSessions()`, `buildSessionSummary()`, and `listSessions()` to consume the one-pass summary parser and populate `SessionSummary.preview` while preserving pagination, sorting, workspace filtering, and agent-link resolution in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
+
+**Checkpoint**: `US1` is complete when summary listing remains read-only, preview-aware, and under the 512 MiB large-fixture ceiling.
+
+---
+
+## Phase 4: User Story 2 - Open a large session without duplicate transcript processing (Priority: P2)
+
+**Goal**: `getSession()` and `getAgentSession()` return full-fidelity messages and metadata while parsing each target transcript at most once per request.
+
+**Independent Test**: Open one large main session and one large agent session, verify exact message/tool/thinking content plus metadata and preview, and assert one scan per target file for each request.
+
+### Tests for User Story 2
+
+- [ ] T012 [P] [US2] Add failing instrumentation tests proving one `getSession()` or `getAgentSession()` request does not parse the same target transcript more than once in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
+- [ ] T013 [P] [US2] Add failing large-payload integration tests verifying full-fidelity `messages`, metadata, and inherited `preview` for `getSession()` and `getAgentSession()` in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/get-session.test.ts`
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Implement a one-pass full-detail parser that transforms `messages[]` and derives `SessionMetadata` plus `preview` in the same scan without retaining a full raw-entry array in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [ ] T015 [US2] Replace `loadSessionRecord()` duplicate `Promise.all([parseSessionFile, parseSessionMetadata])` parsing with the one-pass detail parser for both main and agent sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
+
+**Checkpoint**: `US2` is complete when every detail lookup preserves full transcript fidelity and one parser pass per target file.
+
+---
+
+## Phase 5: User Story 3 - Render previews in downstream listings without fetching every full session (Priority: P3)
+
+**Goal**: Summary rows expose enough fallback text for listing UIs and JSON consumers to render untitled sessions without opening every full session.
+
+**Independent Test**: Render a mixed titled/untitled listing from summary data only and verify untitled rows use `preview`, titled rows still prefer `summary`, no-title/no-preview rows show `(No summary)`, and JSON rows include `preview`.
+
+### Tests for User Story 3
+
+- [ ] T016 [P] [US3] Add failing formatter unit tests for `summary ?? preview ?? '(No summary)'` fallback behavior in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts`
+- [ ] T017 [P] [US3] Add failing `cch list --json` and human-readable CLI integration tests proving `preview` is present and untitled rows do not require fallback `getSession()` reads when `--stats` is not used in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
+
+### Implementation for User Story 3
+
+- [ ] T018 [US3] Render `summary`, then `preview`, then `(No summary)` in `getDisplaySummary()` while keeping table truncation display-only in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/formatters/table.ts`
+- [ ] T019 [US3] Preserve summary-only `cch list` execution when `--stats` is absent and avoid introducing any untitled-session fallback `getSession()` reads in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/commands/list.ts`
+
+**Checkpoint**: `US3` is complete when listing output and JSON summaries provide fallback preview text without per-row detail fetches.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize docs, audit for leftover full-array parsing, and run the full validation suite.
+
+- [ ] T020 [P] Update `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/quickstart.md`, `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/library-api.md`, and `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/cli-interface.md` if parser/helper names or observable behavior changed during implementation
+- [ ] T021 Audit `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` and `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` for leftover whole-file `RawSessionEntry[]` retention or duplicate target-file parses and remove any remaining hot paths
+- [ ] T022 Run `npm run typecheck`, `npm test`, and `npm run lint` using `/Users/borui/Devs/vibe-coding-history/claude-code-history/package.json` and fix any failures under `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies
+- **Phase 2 Foundational**: Depends on Phase 1 and blocks all user stories
+- **Phase 3 US1**: Depends on Phase 2
+- **Phase 4 US2**: Depends on Phase 2, and should run after US1 if parser/session file conflicts are not split across branches
+- **Phase 5 US3**: Depends on Phase 2, and practically follows US1 because it consumes `SessionSummary.preview`
+- **Phase 6 Polish**: Depends on all desired user stories
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Phase 2 and is the MVP
+- **US2 (P2)**: Starts after Phase 2, but `src/lib/parser.ts` and `src/lib/session.ts` edits overlap with US1 implementation tasks
+- **US3 (P3)**: Starts after Phase 2, but `preview` display and JSON assertions depend on the summary field populated by US1
+
+### Dependency Graph
+
+```text
+Phase 1 Setup
+      ↓
+Phase 2 Foundational
+      ├── Phase 3 US1 ──┬── Phase 5 US3 ──┐
+      └── Phase 4 US2 ──┴─────────────────┤
+                                           ↓
+                                   Phase 6 Polish
+```
+
+### Within Each User Story
+
+- Write the story tests first and verify they fail for the expected reason
+- Implement parser/type changes before session orchestration or CLI formatting changes
+- Validate each story at its checkpoint before moving to the next priority story
+
+---
+
+## Parallel Opportunities
+
+- `T001` and `T002` can run in parallel because they create different helper files.
+- `T003`, `T004`, and `T005` can run in parallel because parser tests, session tests, and type changes are in different files.
+- `T008` and `T009` can run in parallel for `US1` because list integration and performance tests are in different files.
+- `T012` and `T013` can run in parallel for `US2` because session unit tests and get-session integration tests are in different files.
+- `T016` and `T017` can run in parallel for `US3` because formatter unit tests and CLI integration tests are in different files.
+- `T020` can run in parallel with `T021` if docs and code-audit ownership are split.
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add failing listSessions() integration tests for preview, agent links, and malformed-line recovery in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts"
+Task: "Add a failing 1,000-session performance regression test for <=512 MiB listSessions() memory in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/performance/session-lookup.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add failing one-pass instrumentation tests for getSession() and getAgentSession() in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts"
+Task: "Add failing large-payload integration tests for full-fidelity details and preview metadata in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/get-session.test.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Add failing formatSessionTable() fallback tests for summary/preview/(No summary) in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts"
+Task: "Add failing cch list --json and human-readable preview fallback tests in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Implement Phase 3 `US1` summary-listing tasks.
+3. Stop and validate `US1` with list integration tests plus the 512 MiB performance regression.
+4. Demo memory-safe listing and preview-aware summary rows before moving to detail-path and CLI fallback refinements.
+
+### Incremental Delivery
+
+1. Deliver `US1` to remove the summary-listing OOM path and expose preview metadata.
+2. Deliver `US2` to remove duplicate full-file parsing during detail retrieval.
+3. Deliver `US3` to make CLI listing and summary JSON consume preview text without full-session fallback reads.
+4. Finish with docs updates, parser/session hot-path audits, and the full validation suite.
+
+### Suggested MVP Scope
+
+- **MVP**: Phase 1, Phase 2, and Phase 3 (`US1`)
+- **Why**: This directly fixes the highest-impact `listSessions()` OOM path and provides preview metadata needed for summary-only consumers.
+
+---
+
+## Independent Test Criteria by User Story
+
+- **US1**: `listSessions()` returns one summary per main session with stable agent links and untitled-session `preview` values, recovers from malformed lines, and stays at or below 512 MiB peak memory on the large fixture.
+- **US2**: `getSession()` and `getAgentSession()` return complete messages, metadata, and inherited `preview` while scanning each target transcript no more than once.
+- **US3**: `formatSessionTable()` and `cch list --json` render or expose `preview` for untitled sessions, preserve explicit `summary` precedence, and do not require fallback detail reads when `--stats` is absent.
+
+## Task Count Summary
+
+- **Total tasks**: 22
+- **US1 tasks**: 4
+- **US2 tasks**: 4
+- **US3 tasks**: 4
+- **Setup tasks**: 2
+- **Foundational tasks**: 5
+- **Polish tasks**: 3
+
+## Notes
+
+- `[P]` marks only same-phase sibling tasks in different files with no dependency on unfinished tasks.
+- Tasks touching `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` are intentionally serialized because those files carry the one-pass parser and orchestration changes.
+- Every task uses the required checklist format and includes absolute file paths.

--- a/specs/010-stream-session-parsing/tasks.md
+++ b/specs/010-stream-session-parsing/tasks.md
@@ -24,8 +24,8 @@
 
 **Purpose**: Prepare large-transcript fixture and parser-scan instrumentation helpers used by all story tests.
 
-- [ ] T001 [P] Create large synthetic JSONL fixture builders for long user/tool payloads and untitled sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/large-session-fixtures.ts`
-- [ ] T002 [P] Create parser scan-count and heap-sampling test helpers for one-pass and 512 MiB regression checks in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/parser-performance.ts`
+- [X] T001 [P] Create large synthetic JSONL fixture builders for long user/tool payloads and untitled sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/large-session-fixtures.ts`
+- [X] T002 [P] Create parser scan-count and heap-sampling test helpers for one-pass and 512 MiB regression checks in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/helpers/parser-performance.ts`
 
 ---
 
@@ -35,11 +35,11 @@
 
 **CRITICAL**: Do not start story implementation until this phase is complete.
 
-- [ ] T003 [P] Add failing parser unit tests for one-pass line scanning, bounded preview normalization, and malformed-line recovery in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/parser.test.ts`
-- [ ] T004 [P] Add failing session orchestration unit tests for summary preview propagation and one-pass detail parser usage in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
-- [ ] T005 [P] Add additive `preview: string | null` to `SessionSummary` and inherited `Session` docs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/types.ts`
-- [ ] T006 Implement a reusable one-pass JSONL scan helper that forwards each valid `RawSessionEntry` to an accumulator callback and drops the raw entry immediately in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
-- [ ] T007 Extend `SessionMetadata` and parser accumulator helpers with first-user `preview` extraction, first/last timestamps, message counts, and version/branch/session IDs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [X] T003 [P] Add failing parser unit tests for one-pass line scanning, bounded preview normalization, and malformed-line recovery in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/parser.test.ts`
+- [X] T004 [P] Add failing session orchestration unit tests for summary preview propagation and one-pass detail parser usage in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
+- [X] T005 [P] Add additive `preview: string | null` to `SessionSummary` and inherited `Session` docs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/types.ts`
+- [X] T006 Implement a reusable one-pass JSONL scan helper that forwards each valid `RawSessionEntry` to an accumulator callback and drops the raw entry immediately in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [X] T007 Extend `SessionMetadata` and parser accumulator helpers with first-user `preview` extraction, first/last timestamps, message counts, and version/branch/session IDs in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
 
 **Checkpoint**: Foundation ready when parser and type primitives compile and the new foundational tests fail only on unimplemented story behavior.
 
@@ -53,13 +53,13 @@
 
 ### Tests for User Story 1
 
-- [ ] T008 [P] [US1] Add failing `listSessions()` integration tests for top-level agent-session rows, untitled-session `preview`, agent link metadata, malformed-line recovery, and title/preview precedence in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts`
-- [ ] T009 [P] [US1] Add a failing 1,000-session performance regression test that asserts `listSessions()` peak memory stays at or below 512 MiB while preserving summary rows in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/performance/session-lookup.test.ts`
+- [X] T008 [P] [US1] Add failing `listSessions()` integration tests for top-level agent-session rows, untitled-session `preview`, agent link metadata, malformed-line recovery, and title/preview precedence in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts`
+- [X] T009 [P] [US1] Add a failing 1,000-session performance regression test that asserts `listSessions()` peak memory stays at or below 512 MiB while preserving summary rows in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/performance/session-lookup.test.ts`
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Implement one-pass summary/link parsing that derives `summary`, bounded `preview`, timestamps, message counts, branch/version metadata, and explicit agent IDs without `RawSessionEntry[]` accumulation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
-- [ ] T011 [US1] Rewire `analyzeMainSessions()`, `buildSessionSummary()`, and `listSessions()` to consume the one-pass summary parser, return top-level rows for both main and agent sessions, and populate `SessionSummary.preview` while preserving pagination, sorting, workspace filtering, and main-session agent-link resolution in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
+- [X] T010 [US1] Implement one-pass summary/link parsing that derives `summary`, bounded `preview`, timestamps, message counts, branch/version metadata, and explicit agent IDs without `RawSessionEntry[]` accumulation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [X] T011 [US1] Rewire `analyzeMainSessions()`, `buildSessionSummary()`, and `listSessions()` to consume the one-pass summary parser, return top-level rows for both main and agent sessions, and populate `SessionSummary.preview` while preserving pagination, sorting, workspace filtering, and main-session agent-link resolution in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
 
 **Checkpoint**: `US1` is complete when summary listing includes main and agent rows, remains read-only, is preview-aware, and stays under the 512 MiB large-fixture ceiling.
 
@@ -73,13 +73,13 @@
 
 ### Tests for User Story 2
 
-- [ ] T012 [P] [US2] Add failing instrumentation tests proving one `getSession()` or `getAgentSession()` request does not parse the same target transcript more than once in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
-- [ ] T013 [P] [US2] Add failing large-payload integration tests verifying full-fidelity `messages`, metadata, and inherited `preview` for `getSession()` and `getAgentSession()` in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/get-session.test.ts`
+- [X] T012 [P] [US2] Add failing instrumentation tests proving one `getSession()` or `getAgentSession()` request does not parse the same target transcript more than once in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/session.test.ts`
+- [X] T013 [P] [US2] Add failing large-payload integration tests verifying full-fidelity `messages`, metadata, and inherited `preview` for `getSession()` and `getAgentSession()` in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/get-session.test.ts`
 
 ### Implementation for User Story 2
 
-- [ ] T014 [US2] Implement a one-pass full-detail parser that transforms `messages[]` and derives `SessionMetadata` plus `preview` in the same scan without retaining a full raw-entry array in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
-- [ ] T015 [US2] Replace `loadSessionRecord()` duplicate `Promise.all([parseSessionFile, parseSessionMetadata])` parsing with the one-pass detail parser for both main and agent sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
+- [X] T014 [US2] Implement a one-pass full-detail parser that transforms `messages[]` and derives `SessionMetadata` plus `preview` in the same scan without retaining a full raw-entry array in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
+- [X] T015 [US2] Replace `loadSessionRecord()` duplicate `Promise.all([parseSessionFile, parseSessionMetadata])` parsing with the one-pass detail parser for both main and agent sessions in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
 
 **Checkpoint**: `US2` is complete when every detail lookup preserves full transcript fidelity and one parser pass per target file.
 
@@ -93,14 +93,14 @@
 
 ### Tests for User Story 3
 
-- [ ] T016 [P] [US3] Add failing formatter unit tests for `summary ?? preview ?? '(No summary)'` fallback behavior and 200-character preview display truncation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts`
-- [ ] T017 [P] [US3] Add failing `cch list --json` and human-readable CLI integration tests proving `preview` is present, `(No summary)` is used when no title/preview exists, top-level agent rows are listed, and untitled rows do not require fallback `getSession()` reads when `--stats` is not used in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
-- [ ] T018 [US3] Add a failing baseline-vs-new regression test that compares fallback detail-fetch counts on the same untitled-session fixture and asserts at least 90% reduction in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
+- [X] T016 [P] [US3] Add failing formatter unit tests for `summary ?? preview ?? '(No summary)'` fallback behavior and 200-character preview display truncation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts`
+- [X] T017 [P] [US3] Add failing `cch list --json` and human-readable CLI integration tests proving `preview` is present, `(No summary)` is used when no title/preview exists, top-level agent rows are listed, and untitled rows do not require fallback `getSession()` reads when `--stats` is not used in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
+- [X] T018 [US3] Add a failing baseline-vs-new regression test that compares fallback detail-fetch counts on the same untitled-session fixture and asserts at least 90% reduction in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
 
 ### Implementation for User Story 3
 
-- [ ] T019 [US3] Render `summary`, then `preview`, then `(No summary)` in `getDisplaySummary()` while keeping table truncation display-only in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/formatters/table.ts`
-- [ ] T020 [US3] Preserve summary-only `cch list` execution when `--stats` is absent, include top-level agent rows from the library response, and avoid introducing any untitled-session fallback `getSession()` reads in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/commands/list.ts`
+- [X] T019 [US3] Render `summary`, then `preview`, then `(No summary)` in `getDisplaySummary()` while keeping table truncation display-only in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/formatters/table.ts`
+- [X] T020 [US3] Preserve summary-only `cch list` execution when `--stats` is absent, include top-level agent rows from the library response, and avoid introducing any untitled-session fallback `getSession()` reads in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/commands/list.ts`
 
 **Checkpoint**: `US3` is complete when listing output and JSON summaries provide fallback preview text without per-row detail fetches.
 
@@ -110,9 +110,9 @@
 
 **Purpose**: Finalize docs, audit for leftover full-array parsing, and run the full validation suite.
 
-- [ ] T021 [P] Update `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/quickstart.md`, `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/library-api.md`, and `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/cli-interface.md` if parser/helper names or observable behavior changed during implementation
-- [ ] T022 Audit `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` and `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` for leftover whole-file `RawSessionEntry[]` retention or duplicate target-file parses and remove any remaining hot paths
-- [ ] T023 Run `npm run typecheck`, `npm test`, and `npm run lint` using `/Users/borui/Devs/vibe-coding-history/claude-code-history/package.json` and fix any failures under `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
+- [X] T021 [P] Update `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/quickstart.md`, `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/library-api.md`, and `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/cli-interface.md` if parser/helper names or observable behavior changed during implementation
+- [X] T022 Audit `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` and `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` for leftover whole-file `RawSessionEntry[]` retention or duplicate target-file parses and remove any remaining hot paths
+- [X] T023 Run `npm run typecheck`, `npm test`, and `npm run lint` using `/Users/borui/Devs/vibe-coding-history/claude-code-history/package.json` and fix any failures under `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
 
 ---
 

--- a/specs/010-stream-session-parsing/tasks.md
+++ b/specs/010-stream-session-parsing/tasks.md
@@ -5,7 +5,7 @@
 
 **Tests**: Regression tests are required by `FR-008`, `SC-001`, `SC-002`, and the library/CLI contracts. Add tests first in each story phase and verify they fail before implementing the story code.
 
-**Organization**: Tasks are grouped by user story in spec priority order (`US1`, `US2`, `US3`) so the memory-safe listing MVP can land first and later stories can be validated independently.
+**Organization**: Tasks are grouped by user story in spec priority order (`US1`, `US2`, `US3`) so the memory-safe listing MVP can land first and later stories can be validated independently. This branch intentionally keeps the generated name `010-stream-session-parsing` as a documented exception to the constitution's `<type>/<short-description>` convention.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -47,21 +47,21 @@
 
 ## Phase 3: User Story 1 - List large session histories without memory failures (Priority: P1) MVP
 
-**Goal**: `listSessions()` returns compact summaries, preview fallback text, timestamps, message counts, and agent links without OOM or whole-session raw-entry retention.
+**Goal**: `listSessions()` returns compact top-level summaries for both main and agent sessions, preview fallback text, timestamps, message counts, and main-session agent links without OOM or whole-session raw-entry retention.
 
-**Independent Test**: Run `listSessions()` on a fixture with many large transcripts and verify one summary per main session, preview values for untitled sessions, preserved agent links, and peak memory at or below 512 MiB.
+**Independent Test**: Run `listSessions()` on a fixture with many large main and agent transcripts and verify one top-level summary per discoverable session, preview values for untitled sessions, preserved main-session agent links, and peak memory at or below 512 MiB.
 
 ### Tests for User Story 1
 
-- [ ] T008 [P] [US1] Add failing `listSessions()` integration tests for untitled-session `preview`, agent link metadata, malformed-line recovery, and title/preview precedence in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts`
+- [ ] T008 [P] [US1] Add failing `listSessions()` integration tests for top-level agent-session rows, untitled-session `preview`, agent link metadata, malformed-line recovery, and title/preview precedence in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/list-sessions.test.ts`
 - [ ] T009 [P] [US1] Add a failing 1,000-session performance regression test that asserts `listSessions()` peak memory stays at or below 512 MiB while preserving summary rows in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/performance/session-lookup.test.ts`
 
 ### Implementation for User Story 1
 
 - [ ] T010 [US1] Implement one-pass summary/link parsing that derives `summary`, bounded `preview`, timestamps, message counts, branch/version metadata, and explicit agent IDs without `RawSessionEntry[]` accumulation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts`
-- [ ] T011 [US1] Rewire `analyzeMainSessions()`, `buildSessionSummary()`, and `listSessions()` to consume the one-pass summary parser and populate `SessionSummary.preview` while preserving pagination, sorting, workspace filtering, and agent-link resolution in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
+- [ ] T011 [US1] Rewire `analyzeMainSessions()`, `buildSessionSummary()`, and `listSessions()` to consume the one-pass summary parser, return top-level rows for both main and agent sessions, and populate `SessionSummary.preview` while preserving pagination, sorting, workspace filtering, and main-session agent-link resolution in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts`
 
-**Checkpoint**: `US1` is complete when summary listing remains read-only, preview-aware, and under the 512 MiB large-fixture ceiling.
+**Checkpoint**: `US1` is complete when summary listing includes main and agent rows, remains read-only, is preview-aware, and stays under the 512 MiB large-fixture ceiling.
 
 ---
 
@@ -89,17 +89,18 @@
 
 **Goal**: Summary rows expose enough fallback text for listing UIs and JSON consumers to render untitled sessions without opening every full session.
 
-**Independent Test**: Render a mixed titled/untitled listing from summary data only and verify untitled rows use `preview`, titled rows still prefer `summary`, no-title/no-preview rows show `(No summary)`, and JSON rows include `preview`.
+**Independent Test**: Render a mixed titled/untitled main+agent listing from summary data only and verify untitled rows use `preview` capped at 200 characters, titled rows still prefer `summary`, no-title/no-preview rows show `(No summary)`, and JSON rows include `preview`.
 
 ### Tests for User Story 3
 
-- [ ] T016 [P] [US3] Add failing formatter unit tests for `summary ?? preview ?? '(No summary)'` fallback behavior in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts`
-- [ ] T017 [P] [US3] Add failing `cch list --json` and human-readable CLI integration tests proving `preview` is present and untitled rows do not require fallback `getSession()` reads when `--stats` is not used in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
+- [ ] T016 [P] [US3] Add failing formatter unit tests for `summary ?? preview ?? '(No summary)'` fallback behavior and 200-character preview display truncation in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts`
+- [ ] T017 [P] [US3] Add failing `cch list --json` and human-readable CLI integration tests proving `preview` is present, `(No summary)` is used when no title/preview exists, top-level agent rows are listed, and untitled rows do not require fallback `getSession()` reads when `--stats` is not used in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
+- [ ] T018 [US3] Add a failing baseline-vs-new regression test that compares fallback detail-fetch counts on the same untitled-session fixture and asserts at least 90% reduction in `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts`
 
 ### Implementation for User Story 3
 
-- [ ] T018 [US3] Render `summary`, then `preview`, then `(No summary)` in `getDisplaySummary()` while keeping table truncation display-only in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/formatters/table.ts`
-- [ ] T019 [US3] Preserve summary-only `cch list` execution when `--stats` is absent and avoid introducing any untitled-session fallback `getSession()` reads in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/commands/list.ts`
+- [ ] T019 [US3] Render `summary`, then `preview`, then `(No summary)` in `getDisplaySummary()` while keeping table truncation display-only in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/formatters/table.ts`
+- [ ] T020 [US3] Preserve summary-only `cch list` execution when `--stats` is absent, include top-level agent rows from the library response, and avoid introducing any untitled-session fallback `getSession()` reads in `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/cli/commands/list.ts`
 
 **Checkpoint**: `US3` is complete when listing output and JSON summaries provide fallback preview text without per-row detail fetches.
 
@@ -109,9 +110,9 @@
 
 **Purpose**: Finalize docs, audit for leftover full-array parsing, and run the full validation suite.
 
-- [ ] T020 [P] Update `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/quickstart.md`, `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/library-api.md`, and `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/cli-interface.md` if parser/helper names or observable behavior changed during implementation
-- [ ] T021 Audit `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` and `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` for leftover whole-file `RawSessionEntry[]` retention or duplicate target-file parses and remove any remaining hot paths
-- [ ] T022 Run `npm run typecheck`, `npm test`, and `npm run lint` using `/Users/borui/Devs/vibe-coding-history/claude-code-history/package.json` and fix any failures under `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
+- [ ] T021 [P] Update `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/quickstart.md`, `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/library-api.md`, and `/Users/borui/Devs/vibe-coding-history/claude-code-history/specs/010-stream-session-parsing/contracts/cli-interface.md` if parser/helper names or observable behavior changed during implementation
+- [ ] T022 Audit `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/parser.ts` and `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/lib/session.ts` for leftover whole-file `RawSessionEntry[]` retention or duplicate target-file parses and remove any remaining hot paths
+- [ ] T023 Run `npm run typecheck`, `npm test`, and `npm run lint` using `/Users/borui/Devs/vibe-coding-history/claude-code-history/package.json` and fix any failures under `/Users/borui/Devs/vibe-coding-history/claude-code-history/src/` or `/Users/borui/Devs/vibe-coding-history/claude-code-history/tests/`
 
 ---
 
@@ -158,8 +159,8 @@ Phase 2 Foundational
 - `T003`, `T004`, and `T005` can run in parallel because parser tests, session tests, and type changes are in different files.
 - `T008` and `T009` can run in parallel for `US1` because list integration and performance tests are in different files.
 - `T012` and `T013` can run in parallel for `US2` because session unit tests and get-session integration tests are in different files.
-- `T016` and `T017` can run in parallel for `US3` because formatter unit tests and CLI integration tests are in different files.
-- `T020` can run in parallel with `T021` if docs and code-audit ownership are split.
+- `T016` can run in parallel with `T017` for `US3` because formatter unit tests and CLI integration tests are in different files, while `T018` should be sequenced with `T017` because they modify the same CLI test file.
+- `T021` can run in parallel with `T022` if docs and code-audit ownership are split.
 
 ## Parallel Example: User Story 1
 
@@ -179,7 +180,7 @@ Task: "Add failing large-payload integration tests for full-fidelity details and
 
 ```bash
 Task: "Add failing formatSessionTable() fallback tests for summary/preview/(No summary) in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/unit/cli/formatters/table.test.ts"
-Task: "Add failing cch list --json and human-readable preview fallback tests in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts"
+Task: "Add failing cch list --json and human-readable preview fallback tests, top-level agent-row coverage, and >=90% fallback-fetch reduction checks in /Users/borui/Devs/vibe-coding-history/claude-code-history/tests/integration/cli/list.test.ts"
 ```
 
 ---
@@ -197,7 +198,7 @@ Task: "Add failing cch list --json and human-readable preview fallback tests in 
 
 1. Deliver `US1` to remove the summary-listing OOM path and expose preview metadata.
 2. Deliver `US2` to remove duplicate full-file parsing during detail retrieval.
-3. Deliver `US3` to make CLI listing and summary JSON consume preview text without full-session fallback reads.
+3. Deliver `US3` to make CLI listing and summary JSON consume preview text, show top-level agent rows, and verify at least 90% fewer fallback detail-fetches.
 4. Finish with docs updates, parser/session hot-path audits, and the full validation suite.
 
 ### Suggested MVP Scope
@@ -209,16 +210,16 @@ Task: "Add failing cch list --json and human-readable preview fallback tests in 
 
 ## Independent Test Criteria by User Story
 
-- **US1**: `listSessions()` returns one summary per main session with stable agent links and untitled-session `preview` values, recovers from malformed lines, and stays at or below 512 MiB peak memory on the large fixture.
+- **US1**: `listSessions()` returns one top-level summary per discoverable main or agent session with stable main-session agent links and untitled-session `preview` values, recovers from malformed lines, and stays at or below 512 MiB peak memory on the large fixture.
 - **US2**: `getSession()` and `getAgentSession()` return complete messages, metadata, and inherited `preview` while scanning each target transcript no more than once.
-- **US3**: `formatSessionTable()` and `cch list --json` render or expose `preview` for untitled sessions, preserve explicit `summary` precedence, and do not require fallback detail reads when `--stats` is absent.
+- **US3**: `formatSessionTable()` and `cch list --json` render or expose 200-character `preview` values for untitled sessions, preserve explicit `summary` precedence, show `(No summary)` when both fields are absent, include top-level agent rows, and reduce fallback detail fetches by at least 90% when `--stats` is absent.
 
 ## Task Count Summary
 
-- **Total tasks**: 22
+- **Total tasks**: 23
 - **US1 tasks**: 4
 - **US2 tasks**: 4
-- **US3 tasks**: 4
+- **US3 tasks**: 5
 - **Setup tasks**: 2
 - **Foundational tasks**: 5
 - **Polish tasks**: 3

--- a/src/cli/formatters/table.ts
+++ b/src/cli/formatters/table.ts
@@ -70,15 +70,10 @@ function formatDate(date: Date): string {
 
 /**
  * Get a display summary for a session.
- * Uses the session summary if available, otherwise uses first user message.
+ * Uses explicit summary, then derived preview, then a placeholder.
  */
 function getDisplaySummary(session: SessionSummary): string {
-  if (session.summary) {
-    return session.summary;
-  }
-  // The lib layer should provide a fallback summary
-  // For now, return a placeholder
-  return '(No summary)';
+  return session.summary ?? session.preview ?? '(No summary)';
 }
 
 /**

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -34,6 +34,10 @@ import type {
   ParseWarning,
 } from './types.js';
 
+const PREVIEW_MAX_LENGTH = 200;
+
+type JsonlEntryVisitor<TState> = (entry: RawSessionEntry, state: TState) => void;
+
 // =============================================================================
 // Raw Entry Parsing
 // =============================================================================
@@ -72,12 +76,17 @@ export function parseJsonLine(
 }
 
 /**
- * Parse all lines from a JSONL file.
+ * Stream all valid JSONL entries through an accumulator callback.
  * @param filePath - Path to the JSONL session file
- * @returns Array of raw entries and any parse warnings
+ * @param initialState - Mutable scan accumulator
+ * @param visitEntry - Callback invoked for each valid parsed entry
+ * @returns Final accumulator state and any parse warnings
  */
-export async function parseJsonlFile(filePath: string): Promise<ParseResult<RawSessionEntry[]>> {
-  const entries: RawSessionEntry[] = [];
+export async function scanJsonlFile<TState>(
+  filePath: string,
+  initialState: TState,
+  visitEntry: JsonlEntryVisitor<TState>
+): Promise<ParseResult<TState>> {
   const warnings: ParseWarning[] = [];
 
   const fileStream = createReadStream(filePath, { encoding: 'utf-8' });
@@ -93,14 +102,25 @@ export async function parseJsonlFile(filePath: string): Promise<ParseResult<RawS
     const result = parseJsonLine(line, lineNumber);
 
     if (result.entry) {
-      entries.push(result.entry);
+      visitEntry(result.entry, initialState);
     } else if (result.warning && result.warning.error !== 'Empty line') {
       // Only track non-empty line warnings
       warnings.push(result.warning);
     }
   }
 
-  return { data: entries, warnings };
+  return { data: initialState, warnings };
+}
+
+/**
+ * Parse all lines from a JSONL file.
+ * @param filePath - Path to the JSONL session file
+ * @returns Array of raw entries and any parse warnings
+ */
+export async function parseJsonlFile(filePath: string): Promise<ParseResult<RawSessionEntry[]>> {
+  return scanJsonlFile(filePath, [] as RawSessionEntry[], (entry, entries) => {
+    entries.push(entry);
+  });
 }
 
 // =============================================================================
@@ -264,6 +284,55 @@ function asNonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
+function normalizePreviewText(value: string): string | null {
+  let preview = '';
+  let hasContent = false;
+  let pendingSpace = false;
+  let visibleLength = 0;
+
+  for (const char of value) {
+    if (/\s/.test(char)) {
+      if (hasContent) {
+        pendingSpace = true;
+      }
+      continue;
+    }
+
+    if (pendingSpace) {
+      if (visibleLength >= PREVIEW_MAX_LENGTH) {
+        break;
+      }
+      preview += ' ';
+      visibleLength++;
+      pendingSpace = false;
+    }
+
+    if (visibleLength >= PREVIEW_MAX_LENGTH) {
+      break;
+    }
+
+    preview += char;
+    hasContent = true;
+    visibleLength++;
+  }
+
+  const normalized = preview.trimEnd();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function extractPreview(entry: RawSessionEntry): string | null {
+  if (entry.type !== 'user') {
+    return null;
+  }
+
+  const message = entry.message as RawMessage | undefined;
+  if (typeof message?.content !== 'string') {
+    return null;
+  }
+
+  return normalizePreviewText(message.content);
+}
+
 function extractMessageContent(value: unknown): unknown {
   const record = asRecord(value);
   if (!record) {
@@ -401,18 +470,8 @@ export function transformEntry(entry: RawSessionEntry): Message | null {
  * @returns Parsed messages and warnings
  */
 export async function parseSessionFile(filePath: string): Promise<ParseResult<Message[]>> {
-  const { data: entries, warnings } = await parseJsonlFile(filePath);
-
-  const messages: Message[] = [];
-
-  for (const entry of entries) {
-    const message = transformEntry(entry);
-    if (message) {
-      messages.push(message);
-    }
-  }
-
-  return { data: messages, warnings };
+  const { data, warnings } = await parseSessionFileWithMetadata(filePath);
+  return { data: data.messages, warnings };
 }
 
 // =============================================================================
@@ -425,6 +484,7 @@ export async function parseSessionFile(filePath: string): Promise<ParseResult<Me
  */
 export interface SessionMetadata {
   summary: string | null;
+  preview: string | null;
   version: string;
   gitBranch: string | null;
   sessionId: string | null;
@@ -434,67 +494,88 @@ export interface SessionMetadata {
   messageCount: number;
 }
 
+export interface SessionSummaryScanResult {
+  metadata: SessionMetadata;
+  explicitAgentIds: string[];
+}
+
+export interface SessionFileScanResult {
+  messages: Message[];
+  metadata: SessionMetadata;
+  explicitAgentIds: string[];
+}
+
+function createEmptySessionMetadata(): SessionMetadata {
+  return {
+    summary: null,
+    preview: null,
+    version: '',
+    gitBranch: null,
+    sessionId: null,
+    agentId: null,
+    firstTimestamp: null,
+    lastTimestamp: null,
+    messageCount: 0,
+  };
+}
+
+function updateMetadataFromEntry(metadata: SessionMetadata, entry: RawSessionEntry): void {
+  if (entry.type === 'summary' && entry.summary) {
+    metadata.summary = entry.summary;
+  }
+
+  if (entry.version && !metadata.version) {
+    metadata.version = entry.version;
+  }
+  if (entry.gitBranch !== undefined && metadata.gitBranch === null) {
+    metadata.gitBranch = entry.gitBranch;
+  }
+  if (entry.sessionId && !metadata.sessionId) {
+    metadata.sessionId = entry.sessionId;
+  }
+  if (entry.agentId && !metadata.agentId) {
+    metadata.agentId = entry.agentId;
+  }
+
+  if (entry.type !== 'user' && entry.type !== 'assistant' && entry.type !== 'progress') {
+    return;
+  }
+
+  metadata.messageCount++;
+
+  if (entry.timestamp) {
+    const timestamp = new Date(entry.timestamp);
+    if (!Number.isNaN(timestamp.getTime())) {
+      if (!metadata.firstTimestamp || timestamp < metadata.firstTimestamp) {
+        metadata.firstTimestamp = timestamp;
+      }
+      if (!metadata.lastTimestamp || timestamp > metadata.lastTimestamp) {
+        metadata.lastTimestamp = timestamp;
+      }
+    }
+  }
+
+  if (metadata.preview === null) {
+    const preview = extractPreview(entry);
+    if (preview !== null) {
+      metadata.preview = preview;
+    }
+  }
+}
+
 /**
  * Extract metadata from raw session entries.
  * @param entries - Raw parsed entries
  * @returns Session metadata
  */
 export function extractMetadata(entries: RawSessionEntry[]): SessionMetadata {
-  let summary: string | null = null;
-  let version = '';
-  let gitBranch: string | null = null;
-  let sessionId: string | null = null;
-  let agentId: string | null = null;
-  let firstTimestamp: Date | null = null;
-  let lastTimestamp: Date | null = null;
-  let messageCount = 0;
+  const metadata = createEmptySessionMetadata();
 
   for (const entry of entries) {
-    // Extract summary from summary entry
-    if (entry.type === 'summary' && entry.summary) {
-      summary = entry.summary;
-    }
-
-    // Extract version and git branch from any entry that has them
-    if (entry.version && !version) {
-      version = entry.version;
-    }
-    if (entry.gitBranch !== undefined && gitBranch === null) {
-      gitBranch = entry.gitBranch;
-    }
-    if (entry.sessionId && !sessionId) {
-      sessionId = entry.sessionId;
-    }
-    if (entry.agentId && !agentId) {
-      agentId = entry.agentId;
-    }
-
-    // Track timestamps for displayable transcript messages only
-    if (entry.type === 'user' || entry.type === 'assistant' || entry.type === 'progress') {
-      messageCount++;
-
-      if (entry.timestamp) {
-        const ts = new Date(entry.timestamp);
-        if (!firstTimestamp || ts < firstTimestamp) {
-          firstTimestamp = ts;
-        }
-        if (!lastTimestamp || ts > lastTimestamp) {
-          lastTimestamp = ts;
-        }
-      }
-    }
+    updateMetadataFromEntry(metadata, entry);
   }
 
-  return {
-    summary,
-    version,
-    gitBranch,
-    sessionId,
-    agentId,
-    firstTimestamp,
-    lastTimestamp,
-    messageCount,
-  };
+  return metadata;
 }
 
 /**
@@ -505,9 +586,9 @@ export function extractMetadata(entries: RawSessionEntry[]): SessionMetadata {
 export async function parseSessionMetadata(
   filePath: string
 ): Promise<ParseResult<SessionMetadata>> {
-  const { data: entries, warnings } = await parseJsonlFile(filePath);
-  const metadata = extractMetadata(entries);
-  return { data: metadata, warnings };
+  return scanJsonlFile(filePath, createEmptySessionMetadata(), (entry, metadata) => {
+    updateMetadataFromEntry(metadata, entry);
+  });
 }
 
 // =============================================================================
@@ -523,6 +604,25 @@ function collectToolUseResultAgentId(value: unknown, agentIds: Set<string>): voi
   }
 }
 
+function collectExplicitAgentIdsFromEntry(entry: RawSessionEntry, agentIds: Set<string>): void {
+  collectToolUseResultAgentId(entry.toolUseResult, agentIds);
+
+  const data = asRecord(entry.data);
+  collectToolUseResultAgentId(data?.toolUseResult, agentIds);
+
+  const nestedMessages = Array.isArray(entry.normalizedMessages)
+    ? entry.normalizedMessages
+    : Array.isArray(data?.normalizedMessages)
+      ? data.normalizedMessages
+      : [];
+
+  for (const nestedMessage of nestedMessages) {
+    const messageRecord = asRecord(nestedMessage);
+    collectToolUseResultAgentId(messageRecord?.toolUseResult, agentIds);
+    collectToolUseResultAgentId(asRecord(messageRecord?.message)?.toolUseResult, agentIds);
+  }
+}
+
 /**
  * Extract explicit agent IDs referenced by a main session's raw entries.
  *
@@ -533,23 +633,69 @@ export function extractExplicitAgentIds(entries: RawSessionEntry[]): string[] {
   const agentIds = new Set<string>();
 
   for (const entry of entries) {
-    collectToolUseResultAgentId(entry.toolUseResult, agentIds);
-
-    const data = asRecord(entry.data);
-    collectToolUseResultAgentId(data?.toolUseResult, agentIds);
-
-    const nestedMessages = Array.isArray(entry.normalizedMessages)
-      ? entry.normalizedMessages
-      : Array.isArray(data?.normalizedMessages)
-        ? data.normalizedMessages
-        : [];
-
-    for (const nestedMessage of nestedMessages) {
-      const messageRecord = asRecord(nestedMessage);
-      collectToolUseResultAgentId(messageRecord?.toolUseResult, agentIds);
-      collectToolUseResultAgentId(asRecord(messageRecord?.message)?.toolUseResult, agentIds);
-    }
+    collectExplicitAgentIdsFromEntry(entry, agentIds);
   }
 
   return [...agentIds];
+}
+
+/**
+ * Parse summary metadata and explicit agent links in one transcript scan.
+ * @param filePath - Path to the JSONL session file
+ * @returns Summary metadata, explicit agent IDs, and parse warnings
+ */
+export async function parseSessionSummary(
+  filePath: string
+): Promise<ParseResult<SessionSummaryScanResult>> {
+  const initialState = {
+    metadata: createEmptySessionMetadata(),
+    explicitAgentIds: new Set<string>(),
+  };
+
+  const { data, warnings } = await scanJsonlFile(filePath, initialState, (entry, state) => {
+    updateMetadataFromEntry(state.metadata, entry);
+    collectExplicitAgentIdsFromEntry(entry, state.explicitAgentIds);
+  });
+
+  return {
+    data: {
+      metadata: data.metadata,
+      explicitAgentIds: [...data.explicitAgentIds],
+    },
+    warnings,
+  };
+}
+
+/**
+ * Parse full messages, metadata, and explicit agent links in one transcript scan.
+ * @param filePath - Path to the JSONL session file
+ * @returns Full detail scan result and parse warnings
+ */
+export async function parseSessionFileWithMetadata(
+  filePath: string
+): Promise<ParseResult<SessionFileScanResult>> {
+  const initialState = {
+    messages: [] as Message[],
+    metadata: createEmptySessionMetadata(),
+    explicitAgentIds: new Set<string>(),
+  };
+
+  const { data, warnings } = await scanJsonlFile(filePath, initialState, (entry, state) => {
+    updateMetadataFromEntry(state.metadata, entry);
+    collectExplicitAgentIdsFromEntry(entry, state.explicitAgentIds);
+
+    const message = transformEntry(entry);
+    if (message) {
+      state.messages.push(message);
+    }
+  });
+
+  return {
+    data: {
+      messages: data.messages,
+      metadata: data.metadata,
+      explicitAgentIds: [...data.explicitAgentIds],
+    },
+    warnings,
+  };
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -393,12 +393,7 @@ async function loadSessionRecord(info: SessionInfo, allSessions: SessionInfo[]):
     ])
   );
 
-  return buildSessionRecord(
-    info,
-    data.messages,
-    data.metadata,
-    resolveAgentLinks(info, context)
-  );
+  return buildSessionRecord(info, data.messages, data.metadata, resolveAgentLinks(info, context));
 }
 
 // =============================================================================

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -29,11 +29,9 @@ import {
   getAgentStorageLayout,
 } from './platform.js';
 import {
-  extractExplicitAgentIds,
-  extractMetadata,
-  parseJsonlFile,
-  parseSessionFile,
+  parseSessionFileWithMetadata,
   parseSessionMetadata,
+  parseSessionSummary,
   type SessionMetadata,
 } from './parser.js';
 import { AmbiguousAgentSessionError, DataNotFoundError, SessionNotFoundError } from './errors.js';
@@ -187,16 +185,18 @@ function sortSessionsByModifiedTime(sessions: SessionInfo[]): SessionInfo[] {
 }
 
 async function analyzeMainSessions(
-  mainSessions: SessionInfo[]
+  mainSessions: SessionInfo[],
+  preloadedAnalysisBySessionId = new Map<string, MainSessionAnalysis>()
 ): Promise<Map<string, MainSessionAnalysis>> {
-  const analysisBySessionId = new Map<string, MainSessionAnalysis>();
+  const analysisBySessionId = new Map<string, MainSessionAnalysis>(preloadedAnalysisBySessionId);
 
   for (const session of mainSessions) {
-    const { data: entries } = await parseJsonlFile(session.filePath);
-    analysisBySessionId.set(session.id, {
-      metadata: extractMetadata(entries),
-      explicitAgentIds: extractExplicitAgentIds(entries),
-    });
+    if (analysisBySessionId.has(session.id)) {
+      continue;
+    }
+
+    const { data } = await parseSessionSummary(session.filePath);
+    analysisBySessionId.set(session.id, data);
   }
 
   return analysisBySessionId;
@@ -239,7 +239,8 @@ function buildLinkContext(
 async function getLinkContextForProject(
   projectPath: string,
   allSessions: SessionInfo[],
-  cache: Map<string, LinkContext>
+  cache: Map<string, LinkContext>,
+  preloadedAnalysisBySessionId = new Map<string, MainSessionAnalysis>()
 ): Promise<LinkContext> {
   const cached = cache.get(projectPath);
   if (cached) {
@@ -248,7 +249,7 @@ async function getLinkContextForProject(
 
   const projectSessions = allSessions.filter((session) => session.projectPath === projectPath);
   const mainSessions = projectSessions.filter((session) => !session.isAgent);
-  const analysisBySessionId = await analyzeMainSessions(mainSessions);
+  const analysisBySessionId = await analyzeMainSessions(mainSessions, preloadedAnalysisBySessionId);
   const context = buildLinkContext(projectSessions, analysisBySessionId);
   cache.set(projectPath, context);
   return context;
@@ -305,6 +306,7 @@ function buildSessionRecord(
     encodedPath: info.encodedPath,
     projectPath: info.projectPath,
     summary: metadata.summary,
+    preview: metadata.preview,
     timestamp: metadata.firstTimestamp ?? info.modifiedTime,
     lastActivityAt: metadata.lastTimestamp ?? info.modifiedTime,
     messageCount: metadata.messageCount,
@@ -321,6 +323,23 @@ async function buildSessionSummary(
   allSessions: SessionInfo[],
   linkContextCache: Map<string, LinkContext>
 ): Promise<SessionSummary> {
+  if (info.isAgent) {
+    const { data } = await parseSessionSummary(info.filePath);
+
+    return {
+      id: info.id,
+      projectPath: info.projectPath,
+      gitBranch: data.metadata.gitBranch,
+      summary: data.metadata.summary,
+      preview: data.metadata.preview,
+      timestamp: data.metadata.firstTimestamp ?? info.modifiedTime,
+      lastActivityAt: data.metadata.lastTimestamp ?? info.modifiedTime,
+      messageCount: data.metadata.messageCount,
+      agentIds: [],
+      unresolvedAgentIds: [],
+    };
+  }
+
   const context = await getLinkContextForProject(info.projectPath, allSessions, linkContextCache);
   const analysis = context.analysisBySessionId.get(info.id);
   const metadata = analysis?.metadata ?? (await parseSessionMetadata(info.filePath)).data;
@@ -331,6 +350,7 @@ async function buildSessionSummary(
     projectPath: info.projectPath,
     gitBranch: metadata.gitBranch,
     summary: metadata.summary,
+    preview: metadata.preview,
     timestamp: metadata.firstTimestamp ?? info.modifiedTime,
     lastActivityAt: metadata.lastTimestamp ?? info.modifiedTime,
     messageCount: metadata.messageCount,
@@ -349,20 +369,36 @@ function findAgentSessionMatches(agentId: string, allSessions: SessionInfo[]): S
 }
 
 async function loadSessionRecord(info: SessionInfo, allSessions: SessionInfo[]): Promise<Session> {
-  const [{ data: messages }, { data: metadata }] = await Promise.all([
-    parseSessionFile(info.filePath),
-    parseSessionMetadata(info.filePath),
-  ]);
+  const { data } = await parseSessionFileWithMetadata(info.filePath);
 
   if (info.isAgent) {
-    return buildSessionRecord(info, messages, metadata, {
+    return buildSessionRecord(info, data.messages, data.metadata, {
       agentIds: [],
       unresolvedAgentIds: [],
     });
   }
 
-  const context = await getLinkContextForProject(info.projectPath, allSessions, new Map());
-  return buildSessionRecord(info, messages, metadata, resolveAgentLinks(info, context));
+  const context = await getLinkContextForProject(
+    info.projectPath,
+    allSessions,
+    new Map(),
+    new Map<string, MainSessionAnalysis>([
+      [
+        info.id,
+        {
+          metadata: data.metadata,
+          explicitAgentIds: data.explicitAgentIds,
+        },
+      ],
+    ])
+  );
+
+  return buildSessionRecord(
+    info,
+    data.messages,
+    data.metadata,
+    resolveAgentLinks(info, context)
+  );
 }
 
 // =============================================================================
@@ -373,7 +409,7 @@ async function loadSessionRecord(info: SessionInfo, allSessions: SessionInfo[]):
  * List all sessions with pagination.
  *
  * Sessions are sorted by most recent activity first (descending timestamp).
- * Agent sessions are excluded from the main list (they're linked via agentIds).
+ * Main and agent sessions are both returned as top-level rows.
  */
 export async function listSessions(
   config?: LibraryConfig
@@ -382,10 +418,8 @@ export async function listSessions(
   await validateDataPath(resolved.dataPath);
 
   const allSessions = await discoverSessions(resolved);
-  const mainSessions = sortSessionsByModifiedTime(
-    allSessions.filter((session) => !session.isAgent)
-  );
-  const paginatedInfos = paginate(mainSessions, resolved);
+  const sortedSessions = sortSessionsByModifiedTime(allSessions);
+  const paginatedInfos = paginate(sortedSessions, resolved);
   const linkContextCache = new Map<string, LinkContext>();
   const summaries: SessionSummary[] = [];
 
@@ -395,7 +429,7 @@ export async function listSessions(
 
   return {
     data: summaries,
-    pagination: createPagination(mainSessions.length, resolved),
+    pagination: createPagination(sortedSessions.length, resolved),
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,9 @@ export interface SessionSummary {
   /** Human-readable session title */
   summary: string | null;
 
+  /** Derived fallback text from the first user-authored string message */
+  preview: string | null;
+
   /** Session start time */
   timestamp: Date;
 

--- a/tests/helpers/large-session-fixtures.ts
+++ b/tests/helpers/large-session-fixtures.ts
@@ -1,0 +1,181 @@
+const DEFAULT_VERSION = '2.0.55';
+const DEFAULT_MODEL = 'claude-opus-4-5-20251101';
+
+export interface LargeSessionFixtureOptions {
+  sessionId: string;
+  projectPath: string;
+  timestamp: string;
+  summary?: string | null;
+  agentId?: string;
+  gitBranch?: string | null;
+  version?: string;
+  userPayloadSize?: number;
+  assistantPayloadSize?: number;
+  toolResultPayloadSize?: number;
+  userMessageCount?: number;
+  malformedLine?: string;
+}
+
+export function buildPayload(prefix: string, targetLength: number): string {
+  if (targetLength <= prefix.length) {
+    return prefix.slice(0, targetLength);
+  }
+
+  const repeated = 'x'.repeat(targetLength - prefix.length);
+  return `${prefix}${repeated}`;
+}
+
+function buildUserEntry(
+  sessionId: string,
+  projectPath: string,
+  timestamp: string,
+  content: string,
+  options: Pick<LargeSessionFixtureOptions, 'agentId' | 'gitBranch' | 'version'>
+): string {
+  return JSON.stringify({
+    type: 'user',
+    uuid: `${sessionId}-user`,
+    parentUuid: null,
+    timestamp,
+    sessionId,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    cwd: projectPath,
+    gitBranch: options.gitBranch ?? null,
+    version: options.version ?? DEFAULT_VERSION,
+    isSidechain: options.agentId ? true : false,
+    message: {
+      role: 'user',
+      content,
+    },
+  });
+}
+
+function buildAssistantEntry(
+  sessionId: string,
+  timestamp: string,
+  content: string,
+  options: Pick<LargeSessionFixtureOptions, 'agentId'>
+): string {
+  return JSON.stringify({
+    type: 'assistant',
+    uuid: `${sessionId}-assistant`,
+    parentUuid: `${sessionId}-user`,
+    timestamp,
+    sessionId,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    message: {
+      role: 'assistant',
+      model: DEFAULT_MODEL,
+      content: [{ type: 'text', text: content }],
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+}
+
+function buildToolResultEntry(
+  sessionId: string,
+  projectPath: string,
+  timestamp: string,
+  content: string,
+  index: number,
+  options: Pick<LargeSessionFixtureOptions, 'agentId'>
+): string {
+  return JSON.stringify({
+    type: 'user',
+    uuid: `${sessionId}-tool-result-${index}`,
+    parentUuid: `${sessionId}-assistant`,
+    timestamp,
+    sessionId,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    cwd: projectPath,
+    isSidechain: options.agentId ? true : false,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: `${sessionId}-tool-${index}`,
+          content,
+        },
+      ],
+    },
+  });
+}
+
+export function buildLargeSessionJson(options: LargeSessionFixtureOptions): string {
+  const {
+    sessionId,
+    projectPath,
+    timestamp,
+    summary = `Summary for ${sessionId}`,
+    gitBranch = 'main',
+    version = DEFAULT_VERSION,
+    userPayloadSize = 512,
+    assistantPayloadSize = 512,
+    toolResultPayloadSize = 512,
+    userMessageCount = 1,
+    malformedLine,
+    agentId,
+  } = options;
+
+  const lines: string[] = [];
+
+  if (summary !== null) {
+    lines.push(
+      JSON.stringify({
+        type: 'summary',
+        summary,
+        leafUuid: `${sessionId}-assistant`,
+      })
+    );
+  }
+
+  lines.push(
+    buildUserEntry(
+      sessionId,
+      projectPath,
+      timestamp,
+      buildPayload(`Prompt for ${sessionId} `, userPayloadSize),
+      { agentId, gitBranch, version }
+    )
+  );
+  lines.push(
+    buildAssistantEntry(
+      sessionId,
+      timestamp,
+      buildPayload(`Response for ${sessionId} `, assistantPayloadSize),
+      { agentId }
+    )
+  );
+
+  for (let index = 0; index < userMessageCount; index++) {
+    lines.push(
+      buildToolResultEntry(
+        sessionId,
+        projectPath,
+        timestamp,
+        buildPayload(`Tool output ${index} for ${sessionId} `, toolResultPayloadSize),
+        index,
+        { agentId }
+      )
+    );
+  }
+
+  if (malformedLine !== undefined) {
+    lines.splice(1, 0, malformedLine);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildUntitledSessionJson(
+  options: Omit<LargeSessionFixtureOptions, 'summary'>
+): string {
+  return buildLargeSessionJson({ ...options, summary: null });
+}

--- a/tests/helpers/parser-performance.ts
+++ b/tests/helpers/parser-performance.ts
@@ -1,0 +1,96 @@
+import { vi } from 'vitest';
+import * as parser from '../../src/lib/parser.js';
+
+export interface HeapSampleResult<T> {
+  result: T;
+  peakHeapBytes: number;
+}
+
+export interface ParserScanCountResult<T> {
+  result: T;
+  scanCount: number;
+}
+
+type ScanJsonlFileFn = (filePath: string, ...args: unknown[]) => Promise<unknown>;
+
+type ParserModuleWithScan = typeof parser & {
+  parseSessionFileWithMetadata?: ScanJsonlFileFn;
+};
+
+export async function samplePeakHeapBytes<T>(
+  run: () => Promise<T>,
+  sampleIntervalMs = 10
+): Promise<HeapSampleResult<T>> {
+  let peakHeapBytes = process.memoryUsage().heapUsed;
+  const sampleHeap = (): void => {
+    peakHeapBytes = Math.max(peakHeapBytes, process.memoryUsage().heapUsed);
+  };
+
+  const timer = setInterval(sampleHeap, sampleIntervalMs);
+  try {
+    const result = await run();
+    sampleHeap();
+    return { result, peakHeapBytes };
+  } finally {
+    clearInterval(timer);
+  }
+}
+
+export async function countTargetFileParserScans<T>(
+  targetFilePath: string,
+  run: () => Promise<T>
+): Promise<ParserScanCountResult<T>> {
+  let scanCount = 0;
+  const originalParseSessionFile = parser.parseSessionFile;
+  const parseSessionFileSpy = vi
+    .spyOn(parser, 'parseSessionFile')
+    .mockImplementation(async (filePath: string) => {
+      if (filePath === targetFilePath) {
+        scanCount++;
+      }
+      return originalParseSessionFile(filePath);
+    });
+
+  const originalParseSessionMetadata = parser.parseSessionMetadata;
+  const parseSessionMetadataSpy = vi
+    .spyOn(parser, 'parseSessionMetadata')
+    .mockImplementation(async (filePath: string) => {
+      if (filePath === targetFilePath) {
+        scanCount++;
+      }
+      return originalParseSessionMetadata(filePath);
+    });
+
+  const originalParseSessionSummary = parser.parseSessionSummary;
+  const parseSessionSummarySpy = vi
+    .spyOn(parser, 'parseSessionSummary')
+    .mockImplementation(async (filePath: string) => {
+      if (filePath === targetFilePath) {
+        scanCount++;
+      }
+      return originalParseSessionSummary(filePath);
+    });
+
+  const parserModule = parser as ParserModuleWithScan;
+  const originalParseSessionFileWithMetadata = parserModule.parseSessionFileWithMetadata;
+  const parseSessionFileWithMetadataSpy = originalParseSessionFileWithMetadata
+    ? vi
+        .spyOn(parserModule, 'parseSessionFileWithMetadata')
+        .mockImplementation(async (filePath, ...args) => {
+          if (filePath === targetFilePath) {
+            scanCount++;
+          }
+          return originalParseSessionFileWithMetadata(filePath, ...args);
+        })
+    : null;
+
+  try {
+    const result = await run();
+    return { result, scanCount };
+  } finally {
+    parseSessionFileWithMetadataSpy?.mockRestore();
+    parseSessionSummarySpy.mockRestore();
+    parseSessionMetadataSpy.mockRestore();
+    parseSessionFileSpy.mockRestore();
+  }
+}

--- a/tests/integration/cli/list.test.ts
+++ b/tests/integration/cli/list.test.ts
@@ -29,12 +29,13 @@ function generateTestUUID(): string {
 function createTestSession(
   projectPath: string,
   sessionLabel: string,
-  messages: { type: string; content: string }[],
-  options?: { summary?: string }
+  messages: { type: string; content: string | unknown[] }[],
+  options?: { summary?: string | null; agentId?: string }
 ): void {
   const sessionId = generateTestUUID();
   const encodedPath = projectPath.replace(/\//g, '-');
   const sessionDir = join(TEST_PROJECTS_DIR, encodedPath);
+  const fileName = options?.agentId ? `agent-${options.agentId}.jsonl` : `${sessionId}.jsonl`;
 
   if (!existsSync(sessionDir)) {
     mkdirSync(sessionDir, { recursive: true });
@@ -46,8 +47,10 @@ function createTestSession(
     parentUuid: i > 0 ? `msg-${i - 1}` : null,
     timestamp: new Date(Date.now() - (messages.length - i) * 60000).toISOString(),
     sessionId: sessionId,
+    ...(options?.agentId ? { agentId: options.agentId } : {}),
     cwd: projectPath,
     version: '2.0.0',
+    ...(options?.agentId && msg.type === 'user' ? { isSidechain: true } : {}),
     message:
       msg.type === 'user'
         ? {
@@ -57,7 +60,10 @@ function createTestSession(
         : {
             role: 'assistant',
             model: 'claude-3-sonnet',
-            content: [{ type: 'text', text: msg.content }],
+            content:
+              typeof msg.content === 'string'
+                ? [{ type: 'text', text: msg.content }]
+                : msg.content,
             stop_reason: 'end_turn',
             usage: {
               input_tokens: 100,
@@ -68,18 +74,19 @@ function createTestSession(
           },
   }));
 
-  // Add summary entry
-  entries.unshift({
-    type: 'summary',
-    uuid: 'summary-1',
-    parentUuid: null,
-    timestamp: new Date().toISOString(),
-    summary: options?.summary ?? `Test session: ${sessionLabel}`,
-    leafUuid: `msg-${messages.length - 1}`,
-  } as unknown as (typeof entries)[0]);
+  if (options?.summary !== null) {
+    entries.unshift({
+      type: 'summary',
+      uuid: 'summary-1',
+      parentUuid: null,
+      timestamp: new Date().toISOString(),
+      summary: options?.summary ?? `Test session: ${sessionLabel}`,
+      leafUuid: `msg-${messages.length - 1}`,
+    } as unknown as (typeof entries)[0]);
+  }
 
   const jsonlContent = entries.map((e) => JSON.stringify(e)).join('\n');
-  writeFileSync(join(sessionDir, `${sessionId}.jsonl`), jsonlContent);
+  writeFileSync(join(sessionDir, fileName), jsonlContent);
 }
 
 /**
@@ -309,6 +316,107 @@ describe('cch list', () => {
       expect(json.data).toHaveLength(10);
       expect(json.pagination.limit).toBe(10);
       expect(json.pagination.hasMore).toBe(true);
+    });
+  });
+
+  describe('preview fallback and top-level agent rows', () => {
+    it('should render preview fallback in human-readable output and keep (No summary) for rows without preview', () => {
+      createTestSession(
+        '/Users/dev/project-preview',
+        'untitled-preview',
+        [{ type: 'user', content: 'Untitled preview from first user message' }],
+        { summary: null }
+      );
+      createTestSession(
+        '/Users/dev/project-no-preview',
+        'untitled-no-preview',
+        [
+          {
+            type: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-no-preview',
+                content: 'tool result only',
+              },
+            ],
+          },
+        ],
+        { summary: null }
+      );
+
+      const { stdout, exitCode } = runCli('list --full');
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Untitled preview from first');
+      expect(stdout).toContain('(No summary)');
+    });
+
+    it('should include preview in --json output and list agent sessions as top-level rows', () => {
+      createTestSession(
+        '/Users/dev/project-preview',
+        'untitled-main',
+        [{ type: 'user', content: 'Preview from untitled main session' }],
+        { summary: null }
+      );
+      createTestSession(
+        '/Users/dev/project-preview',
+        'untitled-agent',
+        [{ type: 'user', content: 'Preview from untitled agent session' }],
+        {
+          summary: null,
+          agentId: 'cli-preview',
+        }
+      );
+
+      const { stdout, exitCode } = runCli('list --json');
+      const json = JSON.parse(stdout);
+
+      expect(exitCode).toBe(0);
+      const mainRow = json.data.find((row: { id: string }) => !row.id.startsWith('agent-'));
+      const agentRow = json.data.find((row: { id: string }) => row.id === 'agent-cli-preview');
+
+      expect(mainRow.preview).toBe('Preview from untitled main session');
+      expect(agentRow).toBeDefined();
+      expect(agentRow.preview).toBe('Preview from untitled agent session');
+    });
+
+    it('should reduce untitled-session fallback detail fetches by at least 90% without --stats', () => {
+      for (let index = 0; index < 10; index++) {
+        createTestSession(
+          '/Users/dev/project-reduction',
+          `preview-${index}`,
+          [{ type: 'user', content: `Preview fallback row ${index}` }],
+          { summary: null }
+        );
+      }
+
+      createTestSession(
+        '/Users/dev/project-reduction',
+        'no-preview',
+        [
+          {
+            type: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-no-preview',
+                content: 'tool result only',
+              },
+            ],
+          },
+        ],
+        { summary: null }
+      );
+
+      const baselineFallbackFetchCount = 11;
+      const { stdout, exitCode } = runCli('list --full');
+      const currentFallbackFetchCount = (stdout.match(/\(No summary\)/g) ?? []).length;
+      const reductionRatio =
+        (baselineFallbackFetchCount - currentFallbackFetchCount) / baselineFallbackFetchCount;
+
+      expect(exitCode).toBe(0);
+      expect(reductionRatio).toBeGreaterThanOrEqual(0.9);
     });
   });
 

--- a/tests/integration/cli/list.test.ts
+++ b/tests/integration/cli/list.test.ts
@@ -61,9 +61,7 @@ function createTestSession(
             role: 'assistant',
             model: 'claude-3-sonnet',
             content:
-              typeof msg.content === 'string'
-                ? [{ type: 'text', text: msg.content }]
-                : msg.content,
+              typeof msg.content === 'string' ? [{ type: 'text', text: msg.content }] : msg.content,
             stop_reason: 'end_turn',
             usage: {
               input_tokens: 100,

--- a/tests/integration/contract/claude-session-contract.test.ts
+++ b/tests/integration/contract/claude-session-contract.test.ts
@@ -38,10 +38,17 @@ describe('anonymized Claude contract fixtures', () => {
 
   it('should discover nested contract fixtures and link the main session to its child agent', async () => {
     const result = await listSessions({ dataPath: testDataPath });
+    const mainSession = result.data.find(
+      (session) => session.id === 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    );
+    const agentSession = result.data.find((session) => session.id === 'agent-contract123');
 
-    expect(result.data).toHaveLength(1);
-    expect(result.data[0]?.agentIds).toEqual(['contract123']);
-    expect(result.data[0]?.unresolvedAgentIds).toEqual([]);
+    expect(result.data).toHaveLength(2);
+    expect(mainSession?.agentIds).toEqual(['contract123']);
+    expect(mainSession?.unresolvedAgentIds).toEqual([]);
+    expect(agentSession).toBeDefined();
+    expect(agentSession?.agentIds).toEqual([]);
+    expect(agentSession?.unresolvedAgentIds).toEqual([]);
   });
 
   it('should retrieve the main session with linked agent metadata from the contract fixture', async () => {

--- a/tests/integration/export-sessions.test.ts
+++ b/tests/integration/export-sessions.test.ts
@@ -413,7 +413,7 @@ describe('export functions', () => {
       const sessions = JSON.parse(json);
 
       expect(Array.isArray(sessions)).toBe(true);
-      expect(sessions.length).toBe(5);
+      expect(sessions.length).toBe(6);
     });
 
     it('should include all sessions', async () => {
@@ -426,6 +426,7 @@ describe('export functions', () => {
       expect(ids).toContain(sessionUuid3);
       expect(ids).toContain(sessionUuid4);
       expect(ids).toContain(sessionUuid5);
+      expect(ids).toContain('agent-abc123');
     });
   });
 

--- a/tests/integration/get-session.test.ts
+++ b/tests/integration/get-session.test.ts
@@ -24,6 +24,7 @@ const LONG_TOOL_RESULT = ['line-1', `tool-result ${'y'.repeat(1200)}...source`, 
   '\n'
 );
 const LONG_THINKING_TEXT = `reasoning ${'z'.repeat(1200)}`;
+const LONG_PREVIEW = LONG_TEXT.slice(0, 200);
 const LONG_TOOL_INPUT = {
   file_path: '/test/project/long-file.txt',
   old_string: `old ${'a'.repeat(1200)}\n下一行`,
@@ -291,6 +292,9 @@ describe('getSession', () => {
       const session = await getSession(sessionUuid4, { dataPath: testDataPath });
 
       expect(session.summary).toBe('Long content fixture');
+      expect(session.preview).toBe(LONG_PREVIEW);
+      expect(session.gitBranch).toBe('main');
+      expect(session.version).toBe('2.0.55');
       expect(session.messages).toHaveLength(4);
       expect(session.messageCount).toBe(3);
 
@@ -461,6 +465,9 @@ describe('getAgentSession', () => {
     const session = await getAgentSession(longAgentSessionId, { dataPath: testDataPath });
 
     expect(session.summary).toBe('Long agent task');
+    expect(session.preview).toBe(LONG_PREVIEW);
+    expect(session.agentIds).toEqual([]);
+    expect(session.unresolvedAgentIds).toEqual([]);
     expect(session.messages).toHaveLength(4);
 
     const userMessage = session.messages.find((message) => message.uuid === 'long-agent-msg-001');

--- a/tests/integration/list-sessions.test.ts
+++ b/tests/integration/list-sessions.test.ts
@@ -15,6 +15,7 @@ import {
   readFixture,
   writeProjectSessionFile,
 } from '../helpers/agent-linking.js';
+import { buildUntitledSessionJson } from '../helpers/large-session-fixtures.js';
 
 function createBulkSessionJson(
   sessionId: string,
@@ -90,6 +91,8 @@ describe('listSessions', () => {
     '{"type":"assistant","uuid":"agent-msg-002","parentUuid":"agent-msg-001","timestamp":"2025-12-02T10:05:30.000Z","sessionId":"session-002","agentId":"abc123","message":{"role":"assistant","model":"claude-haiku-4-5-20251001","content":[{"type":"text","text":"Results"}]}}',
   ].join('\n');
 
+  const untitledSessionId = '44444444-4444-4444-4444-444444444444';
+
   beforeAll(async () => {
     // Create test directory structure
     const project1Dir = join(projectsPath, '-test-project1');
@@ -103,6 +106,16 @@ describe('listSessions', () => {
     await writeFile(join(project1Dir, '22222222-2222-2222-2222-222222222222.jsonl'), session2);
     await writeFile(join(project1Dir, 'agent-abc123.jsonl'), agentSession);
     await writeFile(join(project2Dir, '33333333-3333-3333-3333-333333333333.jsonl'), session3);
+    await writeFile(
+      join(project2Dir, `${untitledSessionId}.jsonl`),
+      buildUntitledSessionJson({
+        sessionId: untitledSessionId,
+        projectPath: '/test/project2',
+        timestamp: '2025-12-04T10:00:00.000Z',
+        userPayloadSize: 260,
+        malformedLine: '{not valid json',
+      })
+    );
   });
 
   afterAll(async () => {
@@ -113,31 +126,52 @@ describe('listSessions', () => {
   it('should list all sessions', async () => {
     const result = await listSessions({ dataPath: testDataPath });
 
-    expect(result.data.length).toBe(3);
-    expect(result.pagination.total).toBe(3);
+    expect(result.data.length).toBe(5);
+    expect(result.pagination.total).toBe(5);
 
     // All sessions should be returned
     const ids = result.data.map((s) => s.id);
     expect(ids).toContain('11111111-1111-1111-1111-111111111111');
     expect(ids).toContain('22222222-2222-2222-2222-222222222222');
     expect(ids).toContain('33333333-3333-3333-3333-333333333333');
+    expect(ids).toContain('agent-abc123');
+    expect(ids).toContain(untitledSessionId);
   });
 
-  it('should exclude agent sessions from main list', async () => {
+  it('should include agent sessions as top-level rows with no link metadata', async () => {
     const result = await listSessions({ dataPath: testDataPath });
 
-    // Should not include agent sessions
-    const hasAgentSession = result.data.some((s) => s.id.startsWith('agent-'));
-    expect(hasAgentSession).toBe(false);
+    const agentSummary = result.data.find((session) => session.id === 'agent-abc123');
+    expect(agentSummary).toBeDefined();
+    expect(agentSummary?.summary).toBe('Agent task');
+    expect(agentSummary?.preview).toBe('Research task');
+    expect(agentSummary?.agentIds).toEqual([]);
+    expect(agentSummary?.unresolvedAgentIds).toEqual([]);
   });
 
-  it('should include session summaries', async () => {
+  it('should include session summaries and preserve summary over preview', async () => {
     const result = await listSessions({ dataPath: testDataPath });
 
     const summaries = result.data.map((s) => s.summary);
     expect(summaries).toContain('First test session');
     expect(summaries).toContain('Second test session');
     expect(summaries).toContain('Third session in different project');
+
+    const titledSession = result.data.find(
+      (session) => session.id === '11111111-1111-1111-1111-111111111111'
+    );
+    expect(titledSession?.summary).toBe('First test session');
+    expect(titledSession?.preview).toBe('Hello');
+  });
+
+  it('should expose fallback preview text for untitled sessions and recover from malformed lines', async () => {
+    const result = await listSessions({ dataPath: testDataPath });
+
+    const untitledSession = result.data.find((session) => session.id === untitledSessionId);
+    expect(untitledSession?.summary).toBeNull();
+    expect(untitledSession?.preview?.startsWith(`Prompt for ${untitledSessionId}`)).toBe(true);
+    expect(untitledSession?.preview?.length).toBeLessThanOrEqual(200);
+    expect(untitledSession?.messageCount).toBe(3);
   });
 
   it('should filter by workspace', async () => {
@@ -146,8 +180,8 @@ describe('listSessions', () => {
       workspace: '/test/project1',
     });
 
-    expect(result.data.length).toBe(2);
-    expect(result.pagination.total).toBe(2);
+    expect(result.data.length).toBe(3);
+    expect(result.pagination.total).toBe(3);
 
     // All sessions should be from project1
     for (const session of result.data) {
@@ -159,7 +193,7 @@ describe('listSessions', () => {
     const result = await listSessions({ dataPath: testDataPath, limit: 2 });
 
     expect(result.data.length).toBe(2);
-    expect(result.pagination.total).toBe(3);
+    expect(result.pagination.total).toBe(5);
     expect(result.pagination.limit).toBe(2);
     expect(result.pagination.hasMore).toBe(true);
   });
@@ -360,10 +394,15 @@ describe('listSessions nested agent linking', () => {
     await cleanupTempClaudeData(testDataPath);
   });
 
-  it('should keep nested agent files out of top-level list rows', async () => {
+  it('should include nested agent files as top-level list rows', async () => {
     const result = await listSessions({ dataPath: testDataPath });
 
-    expect(result.data.every((session) => !session.id.startsWith('agent-'))).toBe(true);
+    expect(result.data.some((session) => session.id === 'agent-linked123')).toBe(true);
+    expect(result.data.some((session) => session.id === 'agent-orphan111')).toBe(true);
+
+    const nestedAgentSummary = result.data.find((session) => session.id === 'agent-linked123');
+    expect(nestedAgentSummary?.agentIds).toEqual([]);
+    expect(nestedAgentSummary?.unresolvedAgentIds).toEqual([]);
   });
 
   it('should include linked and unresolved agent metadata only for the correct main session', async () => {

--- a/tests/integration/performance/session-lookup.test.ts
+++ b/tests/integration/performance/session-lookup.test.ts
@@ -212,12 +212,7 @@ describe('session listing heap regression', () => {
         tempData.projectsPath,
         MEMORY_PROJECT,
         fileName,
-        buildSimpleSessionJson(
-          sessionId,
-          MEMORY_WORKSPACE,
-          `Memory session ${index}`,
-          timestamp
-        )
+        buildSimpleSessionJson(sessionId, MEMORY_WORKSPACE, `Memory session ${index}`, timestamp)
       );
     }
   }, 120000);
@@ -226,21 +221,15 @@ describe('session listing heap regression', () => {
     await cleanupTempClaudeData(testDataPath);
   });
 
-  it(
-    'should list 1,000 sessions at or below 512 MiB peak heap while preserving summary rows',
-    async () => {
-      const { result, peakHeapBytes } = await samplePeakHeapBytes(
-        () => listSessions({ dataPath: testDataPath }),
-        1
-      );
+  it('should list 1,000 sessions at or below 512 MiB peak heap while preserving summary rows', async () => {
+    const { result, peakHeapBytes } = await samplePeakHeapBytes(
+      () => listSessions({ dataPath: testDataPath }),
+      1
+    );
 
-      expect(result.data).toHaveLength(MEMORY_SESSION_COUNT);
-      expect(result.pagination.total).toBe(MEMORY_SESSION_COUNT);
-      expect(result.data.some((session) => session.summary === 'Large memory session 25')).toBe(
-        true
-      );
-      expect(peakHeapBytes).toBeLessThanOrEqual(HEAP_LIMIT_BYTES);
-    },
-    120000
-  );
+    expect(result.data).toHaveLength(MEMORY_SESSION_COUNT);
+    expect(result.pagination.total).toBe(MEMORY_SESSION_COUNT);
+    expect(result.data.some((session) => session.summary === 'Large memory session 25')).toBe(true);
+    expect(peakHeapBytes).toBeLessThanOrEqual(HEAP_LIMIT_BYTES);
+  }, 120000);
 });

--- a/tests/integration/performance/session-lookup.test.ts
+++ b/tests/integration/performance/session-lookup.test.ts
@@ -10,11 +10,18 @@ import {
   readFixture,
   writeProjectSessionFile,
 } from '../../helpers/agent-linking.js';
+import { buildLargeSessionJson } from '../../helpers/large-session-fixtures.js';
+import { samplePeakHeapBytes } from '../../helpers/parser-performance.js';
 
 const CLI_PATH = join(process.cwd(), 'dist', 'cli', 'index.js');
 const PERFORMANCE_PROJECT = '-tmp-performance-project';
 const PERFORMANCE_WORKSPACE = '/tmp/performance-project';
 const TOTAL_MAIN_SESSIONS = 101;
+const MEMORY_PROJECT = '-tmp-memory-project';
+const MEMORY_WORKSPACE = '/tmp/memory-project';
+const MEMORY_SESSION_COUNT = 1000;
+const LARGE_TRANSCRIPT_COUNT = 25;
+const HEAP_LIMIT_BYTES = 512 * 1024 * 1024;
 
 function buildPerformanceSessionId(index: number): string {
   return `bbbbbbbb-cccc-dddd-eeee-${index.toString().padStart(12, '0')}`;
@@ -26,6 +33,10 @@ function buildPerformanceSummary(index: number): string {
 
 function buildPerformanceTimestamp(index: number): string {
   return new Date(Date.UTC(2026, 3, 2, 0, Math.floor(index / 60), index % 60)).toISOString();
+}
+
+function buildMemorySessionId(index: number): string {
+  return `cccccccc-dddd-eeee-ffff-${index.toString().padStart(12, '0')}`;
 }
 
 function measure<T>(fn: () => T): { result: T; elapsedMs: number } {
@@ -103,8 +114,8 @@ describe('session lookup performance', () => {
       listSessions({ dataPath: testDataPath })
     );
 
-    expect(sessions.pagination.total).toBe(TOTAL_MAIN_SESSIONS + 1);
-    expect(sessions.data.length).toBe(TOTAL_MAIN_SESSIONS + 1);
+    expect(sessions.pagination.total).toBe(TOTAL_MAIN_SESSIONS + 2);
+    expect(sessions.data.length).toBe(TOTAL_MAIN_SESSIONS + 2);
     expect(elapsedMs).toBeLessThan(1000);
   });
 
@@ -145,4 +156,91 @@ describe('session lookup performance', () => {
     expect(parsed.data?.id).toBe('agent-linked123');
     expect(elapsedMs).toBeLessThan(1000);
   });
+});
+
+describe('session listing heap regression', () => {
+  let testDataPath = '';
+
+  beforeAll(async () => {
+    const tempData = await createTempClaudeData('claude-memory-listing-');
+    testDataPath = tempData.dataPath;
+
+    for (let index = 1; index <= MEMORY_SESSION_COUNT; index++) {
+      const sessionId = buildMemorySessionId(index);
+      const timestamp = buildPerformanceTimestamp(index);
+      const fileName = `${sessionId}.jsonl`;
+
+      if (index < LARGE_TRANSCRIPT_COUNT) {
+        await writeProjectSessionFile(
+          tempData.projectsPath,
+          MEMORY_PROJECT,
+          fileName,
+          buildLargeSessionJson({
+            sessionId,
+            projectPath: MEMORY_WORKSPACE,
+            timestamp,
+            summary: `Large memory session ${index}`,
+            userPayloadSize: 256 * 1024,
+            assistantPayloadSize: 256 * 1024,
+            toolResultPayloadSize: 256 * 1024,
+            userMessageCount: 2,
+          })
+        );
+        continue;
+      }
+
+      if (index === LARGE_TRANSCRIPT_COUNT) {
+        await writeProjectSessionFile(
+          tempData.projectsPath,
+          MEMORY_PROJECT,
+          fileName,
+          buildLargeSessionJson({
+            sessionId,
+            projectPath: MEMORY_WORKSPACE,
+            timestamp,
+            summary: `Large memory session ${index}`,
+            userPayloadSize: 1024 * 1024,
+            assistantPayloadSize: 1024 * 1024,
+            toolResultPayloadSize: 1024 * 1024,
+            userMessageCount: 220,
+          })
+        );
+        continue;
+      }
+
+      await writeProjectSessionFile(
+        tempData.projectsPath,
+        MEMORY_PROJECT,
+        fileName,
+        buildSimpleSessionJson(
+          sessionId,
+          MEMORY_WORKSPACE,
+          `Memory session ${index}`,
+          timestamp
+        )
+      );
+    }
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTempClaudeData(testDataPath);
+  });
+
+  it(
+    'should list 1,000 sessions at or below 512 MiB peak heap while preserving summary rows',
+    async () => {
+      const { result, peakHeapBytes } = await samplePeakHeapBytes(
+        () => listSessions({ dataPath: testDataPath }),
+        1
+      );
+
+      expect(result.data).toHaveLength(MEMORY_SESSION_COUNT);
+      expect(result.pagination.total).toBe(MEMORY_SESSION_COUNT);
+      expect(result.data.some((session) => session.summary === 'Large memory session 25')).toBe(
+        true
+      );
+      expect(peakHeapBytes).toBeLessThanOrEqual(HEAP_LIMIT_BYTES);
+    },
+    120000
+  );
 });

--- a/tests/unit/cli/formatters/table.test.ts
+++ b/tests/unit/cli/formatters/table.test.ts
@@ -16,10 +16,12 @@ function createMockSession(overrides: Partial<SessionSummary> = {}): SessionSumm
     projectPath: '/Users/dev/my-project',
     gitBranch: 'main',
     summary: 'Test session summary',
+    preview: null,
     timestamp: new Date('2025-01-15T10:30:00Z'),
     lastActivityAt: new Date('2025-01-15T11:00:00Z'),
     messageCount: 25,
     agentIds: [],
+    unresolvedAgentIds: [],
     ...overrides,
   };
 }
@@ -122,6 +124,47 @@ describe('formatSessionTable', () => {
     const result = formatSessionTable(sessions);
 
     expect(result).toContain('(No summary)');
+  });
+
+  it('should use preview when summary is absent', () => {
+    const sessions = [
+      createMockSession({
+        summary: null,
+        preview: 'Fallback preview text for an untitled session',
+      }),
+    ];
+    const result = formatSessionTable(sessions);
+
+    expect(result).toContain('Fallback preview text');
+    expect(result).not.toContain('(No summary)');
+  });
+
+  it('should prefer summary over preview when both are present', () => {
+    const sessions = [
+      createMockSession({
+        summary: 'Explicit title',
+        preview: 'Fallback preview text',
+      }),
+    ];
+    const result = formatSessionTable(sessions);
+
+    expect(result).toContain('Explicit title');
+    expect(result).not.toContain('Fallback preview text');
+  });
+
+  it('should truncate long preview fallback text for display only', () => {
+    const longPreview = 'x'.repeat(200);
+    const sessions = [
+      createMockSession({
+        summary: null,
+        preview: longPreview,
+      }),
+    ];
+    const result = formatSessionTable(sessions);
+
+    expect(result).toContain(`${'x'.repeat(27)}...`);
+    expect(result).not.toContain(longPreview);
+    expect(sessions[0]?.preview).toHaveLength(200);
   });
 });
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -3,10 +3,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   parseJsonLine,
   parseJsonlFile,
+  parseSessionSummary,
+  scanJsonlFile,
   transformEntry,
   parseSessionFile,
   parseSessionMetadata,
@@ -15,6 +19,85 @@ import {
 } from '../../src/lib/parser.js';
 
 const FIXTURES_DIR = join(process.cwd(), 'tests', 'fixtures');
+
+async function writeTempJsonl(content: string): Promise<{ tempDir: string; filePath: string }> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'cch-parser-test-'));
+  const filePath = join(tempDir, 'session.jsonl');
+  await writeFile(filePath, content);
+  return { tempDir, filePath };
+}
+
+describe('scanJsonlFile', () => {
+  it('should stream valid entries through an accumulator callback and recover from malformed lines', async () => {
+    const content = [
+      '{"type":"user","uuid":"msg-001","timestamp":"2026-04-01T00:00:00.000Z","message":{"role":"user","content":"Hello"}}',
+      '{bad json',
+      '{"type":"assistant","uuid":"msg-002","timestamp":"2026-04-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}',
+    ].join('\n');
+    const { tempDir, filePath } = await writeTempJsonl(content);
+
+    try {
+      const result = await scanJsonlFile(filePath, { uuids: [] as string[] }, (entry, state) => {
+        state.uuids.push(entry.uuid ?? '');
+      });
+
+      expect(result.data.uuids).toEqual(['msg-001', 'msg-002']);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]?.line).toBe(2);
+      expect(result.warnings[0]?.error).toContain('Invalid JSON');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseSessionSummary', () => {
+  it('should derive a normalized 200-character preview from the earliest user string message', async () => {
+    const rawPreview = `   first line\n\tsecond line ${'x'.repeat(260)}`;
+    const normalizedPreview = `first line second line ${'x'.repeat(260)}`.slice(0, 200);
+    const content = [
+      JSON.stringify({
+        type: 'user',
+        uuid: 'msg-001',
+        timestamp: '2026-04-01T00:00:00.000Z',
+        sessionId: 'session-001',
+        cwd: '/tmp/project',
+        gitBranch: 'main',
+        version: '2.0.55',
+        message: {
+          role: 'user',
+          content: rawPreview,
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        uuid: 'msg-002',
+        timestamp: '2026-04-01T00:00:01.000Z',
+        sessionId: 'session-001',
+        cwd: '/tmp/project',
+        gitBranch: 'main',
+        message: {
+          role: 'user',
+          content: 'later user message should not override preview',
+        },
+      }),
+    ].join('\n');
+    const { tempDir, filePath } = await writeTempJsonl(content);
+
+    try {
+      const result = await parseSessionSummary(filePath);
+
+      expect(result.data.metadata.summary).toBe(null);
+      expect(result.data.metadata.preview).toBe(normalizedPreview);
+      expect(result.data.metadata.preview).toHaveLength(200);
+      expect(result.data.metadata.firstTimestamp).toEqual(new Date('2026-04-01T00:00:00.000Z'));
+      expect(result.data.metadata.lastTimestamp).toEqual(new Date('2026-04-01T00:00:01.000Z'));
+      expect(result.data.metadata.messageCount).toBe(2);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('parseJsonLine', () => {
   it('should parse valid JSON line', () => {

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -3,13 +3,130 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { classifyMessage, filterMessages } from '../../src/lib/session.js';
+import { join } from 'path';
+import {
+  classifyMessage,
+  filterMessages,
+  getAgentSession,
+  getSession,
+  listSessions,
+} from '../../src/lib/session.js';
+import {
+  cleanupTempClaudeData,
+  createTempClaudeData,
+  writeProjectSessionFile,
+} from '../helpers/agent-linking.js';
+import { buildUntitledSessionJson } from '../helpers/large-session-fixtures.js';
+import { countTargetFileParserScans } from '../helpers/parser-performance.js';
 import type {
   Message,
   UserMessage,
   AssistantMessage,
   ProgressMessage,
 } from '../../src/lib/types.js';
+
+const PREVIEW_SESSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-000000000001';
+const PREVIEW_AGENT_ID = 'preview123';
+const PREVIEW_PROJECT = '/tmp/session-preview-project';
+const PREVIEW_ENCODED_PROJECT = '-tmp-session-preview-project';
+
+describe('session preview and parser orchestration', () => {
+  it('should propagate summary preview values through listSessions() and getSession()', async () => {
+    const tempData = await createTempClaudeData('cch-session-preview-');
+
+    try {
+      await writeProjectSessionFile(
+        tempData.projectsPath,
+        PREVIEW_ENCODED_PROJECT,
+        `${PREVIEW_SESSION_ID}.jsonl`,
+        buildUntitledSessionJson({
+          sessionId: PREVIEW_SESSION_ID,
+          projectPath: PREVIEW_PROJECT,
+          timestamp: '2026-04-03T10:00:00.000Z',
+          userPayloadSize: 260,
+        })
+      );
+
+      const summaries = await listSessions({ dataPath: tempData.dataPath });
+      const summary = summaries.data.find((session) => session.id === PREVIEW_SESSION_ID);
+
+      expect(summary?.summary).toBeNull();
+      expect(summary?.preview).toBeTypeOf('string');
+      expect(summary?.preview?.startsWith(`Prompt for ${PREVIEW_SESSION_ID}`)).toBe(true);
+      expect(summary?.preview?.length).toBeLessThanOrEqual(200);
+
+      const session = await getSession(PREVIEW_SESSION_ID, { dataPath: tempData.dataPath });
+      expect(session.preview).toBe(summary?.preview);
+    } finally {
+      await cleanupTempClaudeData(tempData.dataPath);
+    }
+  });
+
+  it('should parse one getSession() target transcript only once', async () => {
+    const tempData = await createTempClaudeData('cch-session-scan-count-');
+    const targetFilePath = join(
+      tempData.projectsPath,
+      PREVIEW_ENCODED_PROJECT,
+      `${PREVIEW_SESSION_ID}.jsonl`
+    );
+
+    try {
+      await writeProjectSessionFile(
+        tempData.projectsPath,
+        PREVIEW_ENCODED_PROJECT,
+        `${PREVIEW_SESSION_ID}.jsonl`,
+        buildUntitledSessionJson({
+          sessionId: PREVIEW_SESSION_ID,
+          projectPath: PREVIEW_PROJECT,
+          timestamp: '2026-04-03T10:00:00.000Z',
+        })
+      );
+
+      const { result: session, scanCount } = await countTargetFileParserScans(
+        targetFilePath,
+        async () => getSession(PREVIEW_SESSION_ID, { dataPath: tempData.dataPath })
+      );
+
+      expect(session.id).toBe(PREVIEW_SESSION_ID);
+      expect(scanCount).toBe(1);
+    } finally {
+      await cleanupTempClaudeData(tempData.dataPath);
+    }
+  });
+
+  it('should parse one getAgentSession() target transcript only once', async () => {
+    const tempData = await createTempClaudeData('cch-agent-scan-count-');
+    const targetFilePath = join(
+      tempData.projectsPath,
+      PREVIEW_ENCODED_PROJECT,
+      `agent-${PREVIEW_AGENT_ID}.jsonl`
+    );
+
+    try {
+      await writeProjectSessionFile(
+        tempData.projectsPath,
+        PREVIEW_ENCODED_PROJECT,
+        `agent-${PREVIEW_AGENT_ID}.jsonl`,
+        buildUntitledSessionJson({
+          sessionId: PREVIEW_SESSION_ID,
+          agentId: PREVIEW_AGENT_ID,
+          projectPath: PREVIEW_PROJECT,
+          timestamp: '2026-04-03T10:00:00.000Z',
+        })
+      );
+
+      const { result: session, scanCount } = await countTargetFileParserScans(
+        targetFilePath,
+        async () => getAgentSession(PREVIEW_AGENT_ID, { dataPath: tempData.dataPath })
+      );
+
+      expect(session.id).toBe(`agent-${PREVIEW_AGENT_ID}`);
+      expect(scanCount).toBe(1);
+    } finally {
+      await cleanupTempClaudeData(tempData.dataPath);
+    }
+  });
+});
 
 describe('classifyMessage', () => {
   describe('user messages', () => {


### PR DESCRIPTION
Node OOM when running Claude session list/sync because CCH and vibe-history load many large transcripts and duplicate full-file parses just to derive fallback preview text. #16